### PR TITLE
[feat] 관리자 포인트 정책 목록 조회, 수정 기능 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <scope>runtime</scope>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -114,7 +114,6 @@
             <artifactId>querydsl-jpa</artifactId>
             <version>5.0.0</version>
         </dependency>
-
         <dependency>
             <groupId>com.querydsl</groupId>
             <artifactId>querydsl-apt</artifactId>
@@ -188,9 +187,6 @@
                 <groupId>com.mysema.maven</groupId>
                 <artifactId>apt-maven-plugin</artifactId>
                 <version>1.1.3</version>
-                <configuration>
-                    <processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
-                </configuration>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -198,7 +194,8 @@
                             <goal>process</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>target/generated-sources/annotations</outputDirectory>
+                            <outputDirectory>target/generated-sources/java</outputDirectory>
+                            <processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/shop/bookbom/shop/common/exception/ErrorCode.java
+++ b/src/main/java/shop/bookbom/shop/common/exception/ErrorCode.java
@@ -34,6 +34,8 @@ public enum ErrorCode {
     TAG_ALREADY_EXIST(400, "해당 태그가 이미 존재합니다."),
     // file
     FILE_NOT_FOUND(400, "해당 파일을 찾을 수 없습니다."),
+    // point_rate
+    POINT_RATE_NOT_FOUND(400, "해당 포인트 정책이 존재하지 않습니다."),
     ;
     private final int code;
     private final String message;

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/controller/PointRateController.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/controller/PointRateController.java
@@ -1,0 +1,21 @@
+package shop.bookbom.shop.domain.pointrate.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shop.bookbom.shop.domain.pointrate.repository.dto.PointRateResponse;
+import shop.bookbom.shop.domain.pointrate.service.PointRateService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/shop")
+public class PointRateController {
+    private final PointRateService pointRateService;
+
+    @GetMapping("/point-rate")
+    public List<PointRateResponse> getAllPolicies() {
+        return pointRateService.getPointPolicies();
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/controller/PointRateController.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/controller/PointRateController.java
@@ -5,6 +5,7 @@ import static shop.bookbom.shop.common.CommonResponse.successWithData;
 
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -13,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import shop.bookbom.shop.common.CommonListResponse;
 import shop.bookbom.shop.common.CommonResponse;
+import shop.bookbom.shop.common.exception.BaseException;
+import shop.bookbom.shop.common.exception.ErrorCode;
 import shop.bookbom.shop.domain.pointrate.dto.request.PointRateUpdateRequest;
 import shop.bookbom.shop.domain.pointrate.repository.dto.PointRateResponse;
 import shop.bookbom.shop.domain.pointrate.service.PointRateService;
@@ -31,8 +34,13 @@ public class PointRateController {
     @PutMapping("/point-rate/{id}")
     public CommonResponse<PointRateResponse> updatePolicy(
             @PathVariable("id") Long id,
-            @RequestBody @Valid PointRateUpdateRequest request
+            @RequestBody @Valid PointRateUpdateRequest request,
+            BindingResult bindingResult
     ) {
+        if (bindingResult.hasErrors()) {
+            throw new BaseException(ErrorCode.COMMON_INVALID_PARAMETER,
+                    bindingResult.getAllErrors().get(0).getDefaultMessage());
+        }
         PointRateResponse response = pointRateService.updatePolicy(id, request.getEarnType(), request.getEarnPoint());
         return successWithData(response);
     }

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/controller/PointRateController.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/controller/PointRateController.java
@@ -1,10 +1,10 @@
 package shop.bookbom.shop.domain.pointrate.controller;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import shop.bookbom.shop.common.CommonListResponse;
 import shop.bookbom.shop.domain.pointrate.repository.dto.PointRateResponse;
 import shop.bookbom.shop.domain.pointrate.service.PointRateService;
 
@@ -15,7 +15,7 @@ public class PointRateController {
     private final PointRateService pointRateService;
 
     @GetMapping("/point-rate")
-    public List<PointRateResponse> getAllPolicies() {
-        return pointRateService.getPointPolicies();
+    public CommonListResponse<PointRateResponse> getAllPolicies() {
+        return CommonListResponse.successWithList(pointRateService.getPointPolicies());
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/controller/PointRateController.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/controller/PointRateController.java
@@ -1,10 +1,19 @@
 package shop.bookbom.shop.domain.pointrate.controller;
 
+import static shop.bookbom.shop.common.CommonListResponse.successWithList;
+import static shop.bookbom.shop.common.CommonResponse.successWithData;
+
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import shop.bookbom.shop.common.CommonListResponse;
+import shop.bookbom.shop.common.CommonResponse;
+import shop.bookbom.shop.domain.pointrate.dto.request.PointRateUpdateRequest;
 import shop.bookbom.shop.domain.pointrate.repository.dto.PointRateResponse;
 import shop.bookbom.shop.domain.pointrate.service.PointRateService;
 
@@ -16,6 +25,15 @@ public class PointRateController {
 
     @GetMapping("/point-rate")
     public CommonListResponse<PointRateResponse> getAllPolicies() {
-        return CommonListResponse.successWithList(pointRateService.getPointPolicies());
+        return successWithList(pointRateService.getPointPolicies());
+    }
+
+    @PutMapping("/point-rate/{id}")
+    public CommonResponse<PointRateResponse> updatePolicy(
+            @PathVariable("id") Long id,
+            @RequestBody @Valid PointRateUpdateRequest request
+    ) {
+        PointRateResponse response = pointRateService.updatePolicy(id, request.getEarnType(), request.getEarnPoint());
+        return successWithData(response);
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/dto/request/PointRateUpdateRequest.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/dto/request/PointRateUpdateRequest.java
@@ -1,7 +1,7 @@
 package shop.bookbom.shop.domain.pointrate.dto.request;
 
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PointRateUpdateRequest {
-    @NotEmpty(message = "적립 유형은 필수로 입력되어야 합니다.")
+    @NotBlank(message = "적립 유형은 필수로 입력되어야 합니다.")
     private String earnType;
     @Min(value = 1, message = "적립률은 0 이상이어야 합니다.")
     private int earnPoint;

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/dto/request/PointRateUpdateRequest.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/dto/request/PointRateUpdateRequest.java
@@ -2,14 +2,16 @@ package shop.bookbom.shop.domain.pointrate.dto.request;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class PointRateUpdateRequest {
     @NotEmpty(message = "적립 유형은 필수로 입력되어야 합니다.")
     private String earnType;
-    @Min(value = 0, message = "적립률은 0 이상이어야 합니다.")
+    @Min(value = 1, message = "적립률은 0 이상이어야 합니다.")
     private int earnPoint;
 }

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/dto/request/PointRateUpdateRequest.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/dto/request/PointRateUpdateRequest.java
@@ -1,0 +1,15 @@
+package shop.bookbom.shop.domain.pointrate.dto.request;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PointRateUpdateRequest {
+    @NotEmpty(message = "적립 유형은 필수로 입력되어야 합니다.")
+    private String earnType;
+    @Min(value = 0, message = "적립률은 0 이상이어야 합니다.")
+    private int earnPoint;
+}

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/entity/PointRate.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/entity/PointRate.java
@@ -10,6 +10,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -41,6 +42,7 @@ public class PointRate {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    @Builder
     public PointRate(
             String name,
             EarnPointType earnType,

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/entity/PointRate.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/entity/PointRate.java
@@ -56,4 +56,9 @@ public class PointRate {
         this.applyType = applyType;
         this.createdAt = createdAt;
     }
+
+    public void updatePolicy(EarnPointType earnType, int earnPoint) {
+        this.earnType = earnType;
+        this.earnPoint = earnPoint;
+    }
 }

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/exception/PointRateNotFoundException.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/exception/PointRateNotFoundException.java
@@ -8,12 +8,4 @@ public class PointRateNotFoundException extends BaseException {
         super(ErrorCode.POINT_RATE_NOT_FOUND);
 
     }
-
-    public PointRateNotFoundException(ErrorCode errorCode) {
-        super(errorCode);
-    }
-
-    public PointRateNotFoundException(ErrorCode errorCode, String message) {
-        super(errorCode, message);
-    }
 }

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/exception/PointRateNotFoundException.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/exception/PointRateNotFoundException.java
@@ -1,0 +1,19 @@
+package shop.bookbom.shop.domain.pointrate.exception;
+
+import shop.bookbom.shop.common.exception.BaseException;
+import shop.bookbom.shop.common.exception.ErrorCode;
+
+public class PointRateNotFoundException extends BaseException {
+    public PointRateNotFoundException() {
+        super(ErrorCode.POINT_RATE_NOT_FOUND);
+
+    }
+
+    public PointRateNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public PointRateNotFoundException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/repository/PointRateRepository.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/repository/PointRateRepository.java
@@ -1,0 +1,7 @@
+package shop.bookbom.shop.domain.pointrate.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shop.bookbom.shop.domain.pointrate.entity.PointRate;
+
+public interface PointRateRepository extends JpaRepository<PointRate, Long>, PointRateRepositoryCustom {
+}

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/repository/PointRateRepositoryCustom.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/repository/PointRateRepositoryCustom.java
@@ -1,0 +1,8 @@
+package shop.bookbom.shop.domain.pointrate.repository;
+
+import java.util.List;
+import shop.bookbom.shop.domain.pointrate.repository.dto.PointRateResponse;
+
+public interface PointRateRepositoryCustom {
+    List<PointRateResponse> getPointPolicies();
+}

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/repository/dto/PointRateResponse.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/repository/dto/PointRateResponse.java
@@ -1,0 +1,21 @@
+package shop.bookbom.shop.domain.pointrate.repository.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import shop.bookbom.shop.domain.pointrate.entity.EarnPointType;
+
+@Getter
+public class PointRateResponse {
+    private Long id;
+    private String name;
+    private EarnPointType earnType;
+    private int earnPoint;
+
+    @QueryProjection
+    public PointRateResponse(Long id, String name, EarnPointType earnType, int earnPoint) {
+        this.id = id;
+        this.name = name;
+        this.earnType = earnType;
+        this.earnPoint = earnPoint;
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/repository/dto/PointRateResponse.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/repository/dto/PointRateResponse.java
@@ -1,6 +1,7 @@
 package shop.bookbom.shop.domain.pointrate.repository.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
 import lombok.Getter;
 import shop.bookbom.shop.domain.pointrate.entity.EarnPointType;
 
@@ -11,6 +12,7 @@ public class PointRateResponse {
     private EarnPointType earnType;
     private int earnPoint;
 
+    @Builder
     @QueryProjection
     public PointRateResponse(Long id, String name, EarnPointType earnType, int earnPoint) {
         this.id = id;

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/repository/dto/PointRateResponse.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/repository/dto/PointRateResponse.java
@@ -4,6 +4,7 @@ import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 import lombok.Getter;
 import shop.bookbom.shop.domain.pointrate.entity.EarnPointType;
+import shop.bookbom.shop.domain.pointrate.entity.PointRate;
 
 @Getter
 public class PointRateResponse {
@@ -19,5 +20,14 @@ public class PointRateResponse {
         this.name = name;
         this.earnType = earnType;
         this.earnPoint = earnPoint;
+    }
+
+    public static PointRateResponse from(PointRate pointRate) {
+        return PointRateResponse.builder()
+                .id(pointRate.getId())
+                .name(pointRate.getName())
+                .earnType(pointRate.getEarnType())
+                .earnPoint(pointRate.getEarnPoint())
+                .build();
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/repository/impl/PointRateRepositoryImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/repository/impl/PointRateRepositoryImpl.java
@@ -1,0 +1,29 @@
+package shop.bookbom.shop.domain.pointrate.repository.impl;
+
+import static shop.bookbom.shop.domain.pointrate.entity.QPointRate.pointRate;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import javax.persistence.EntityManager;
+import shop.bookbom.shop.domain.pointrate.repository.PointRateRepositoryCustom;
+import shop.bookbom.shop.domain.pointrate.repository.dto.PointRateResponse;
+import shop.bookbom.shop.domain.pointrate.repository.dto.QPointRateResponse;
+
+public class PointRateRepositoryImpl implements PointRateRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    public PointRateRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<PointRateResponse> getPointPolicies() {
+        return queryFactory.select(new QPointRateResponse(
+                        pointRate.id,
+                        pointRate.name,
+                        pointRate.earnType,
+                        pointRate.earnPoint))
+                .from(pointRate)
+                .fetch();
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/service/PointRateService.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/service/PointRateService.java
@@ -1,19 +1,13 @@
 package shop.bookbom.shop.domain.pointrate.service;
 
 import java.util.List;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import shop.bookbom.shop.domain.pointrate.repository.PointRateRepository;
 import shop.bookbom.shop.domain.pointrate.repository.dto.PointRateResponse;
 
-@Service
-@RequiredArgsConstructor
-public class PointRateService {
-    private final PointRateRepository pointRateRepository;
-
-    @Transactional(readOnly = true)
-    public List<PointRateResponse> getPointPolicies() {
-        return pointRateRepository.getPointPolicies();
-    }
+public interface PointRateService {
+    /**
+     * 포인트 정책 목록을 조회하는 메서드입니다.
+     *
+     * @return 포인트 정책 목록
+     */
+    List<PointRateResponse> getPointPolicies();
 }

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/service/PointRateService.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/service/PointRateService.java
@@ -10,4 +10,14 @@ public interface PointRateService {
      * @return 포인트 정책 목록
      */
     List<PointRateResponse> getPointPolicies();
+
+    /**
+     * 포인트 정책을 수정하는 메서드입니다.
+     *
+     * @param id        수정할 포인트 정책의 id
+     * @param earnType  수정할 적립 유형
+     * @param earnPoint 수정할 적립율
+     * @return 수정된 포인트 정책
+     */
+    PointRateResponse updatePolicy(Long id, String earnType, int earnPoint);
 }

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/service/PointRateService.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/service/PointRateService.java
@@ -1,0 +1,19 @@
+package shop.bookbom.shop.domain.pointrate.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.bookbom.shop.domain.pointrate.repository.PointRateRepository;
+import shop.bookbom.shop.domain.pointrate.repository.dto.PointRateResponse;
+
+@Service
+@RequiredArgsConstructor
+public class PointRateService {
+    private final PointRateRepository pointRateRepository;
+
+    @Transactional(readOnly = true)
+    public List<PointRateResponse> getPointPolicies() {
+        return pointRateRepository.getPointPolicies();
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/service/impl/PointRateServiceImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/service/impl/PointRateServiceImpl.java
@@ -4,6 +4,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import shop.bookbom.shop.domain.pointrate.entity.EarnPointType;
+import shop.bookbom.shop.domain.pointrate.entity.PointRate;
+import shop.bookbom.shop.domain.pointrate.exception.PointRateNotFoundException;
 import shop.bookbom.shop.domain.pointrate.repository.PointRateRepository;
 import shop.bookbom.shop.domain.pointrate.repository.dto.PointRateResponse;
 import shop.bookbom.shop.domain.pointrate.service.PointRateService;
@@ -16,5 +19,23 @@ public class PointRateServiceImpl implements PointRateService {
     @Transactional(readOnly = true)
     public List<PointRateResponse> getPointPolicies() {
         return pointRateRepository.getPointPolicies();
+    }
+
+    @Transactional
+    public PointRateResponse updatePolicy(Long id, String earnType, int earnPoint) {
+        PointRate pointRate = pointRateRepository.findById(id)
+                .orElseThrow(PointRateNotFoundException::new);
+        EarnPointType earnPointType = EarnPointType.valueOf(earnType);
+        pointRate.updatePolicy(earnPointType, earnPoint);
+        return pointRateToResponse(pointRate);
+    }
+
+    private PointRateResponse pointRateToResponse(PointRate pointRate) {
+        return PointRateResponse.builder()
+                .id(pointRate.getId())
+                .name(pointRate.getName())
+                .earnType(pointRate.getEarnType())
+                .earnPoint(pointRate.getEarnPoint())
+                .build();
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/service/impl/PointRateServiceImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/service/impl/PointRateServiceImpl.java
@@ -27,15 +27,6 @@ public class PointRateServiceImpl implements PointRateService {
                 .orElseThrow(PointRateNotFoundException::new);
         EarnPointType earnPointType = EarnPointType.valueOf(earnType);
         pointRate.updatePolicy(earnPointType, earnPoint);
-        return pointRateToResponse(pointRate);
-    }
-
-    private PointRateResponse pointRateToResponse(PointRate pointRate) {
-        return PointRateResponse.builder()
-                .id(pointRate.getId())
-                .name(pointRate.getName())
-                .earnType(pointRate.getEarnType())
-                .earnPoint(pointRate.getEarnPoint())
-                .build();
+        return PointRateResponse.from(pointRate);
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/pointrate/service/impl/PointRateServiceImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointrate/service/impl/PointRateServiceImpl.java
@@ -1,0 +1,20 @@
+package shop.bookbom.shop.domain.pointrate.service.impl;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.bookbom.shop.domain.pointrate.repository.PointRateRepository;
+import shop.bookbom.shop.domain.pointrate.repository.dto.PointRateResponse;
+import shop.bookbom.shop.domain.pointrate.service.PointRateService;
+
+@Service
+@RequiredArgsConstructor
+public class PointRateServiceImpl implements PointRateService {
+    private final PointRateRepository pointRateRepository;
+
+    @Transactional(readOnly = true)
+    public List<PointRateResponse> getPointPolicies() {
+        return pointRateRepository.getPointPolicies();
+    }
+}

--- a/src/test/java/shop/bookbom/shop/config/TestQuerydslConfig.java
+++ b/src/test/java/shop/bookbom/shop/config/TestQuerydslConfig.java
@@ -1,0 +1,18 @@
+package shop.bookbom.shop.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestQuerydslConfig {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/test/java/shop/bookbom/shop/domain/pointrate/controller/PointRateControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/pointrate/controller/PointRateControllerTest.java
@@ -1,0 +1,56 @@
+package shop.bookbom.shop.domain.pointrate.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import shop.bookbom.shop.domain.pointrate.entity.EarnPointType;
+import shop.bookbom.shop.domain.pointrate.repository.dto.PointRateResponse;
+import shop.bookbom.shop.domain.pointrate.service.PointRateService;
+
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest(PointRateController.class)
+class PointRateControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    PointRateService pointRateService;
+
+    @Test
+    @DisplayName("포인트 적립 정책 목록 조회")
+    void getAllPolicies() throws Exception {
+        //given
+        PointRateResponse pointRate1 = new PointRateResponse(1L, "테스트1", EarnPointType.RATE, 100);
+        PointRateResponse pointRate2 = new PointRateResponse(2L, "테스트2", EarnPointType.COST, 1000);
+        when(pointRateService.getPointPolicies()).thenReturn(List.of(pointRate1, pointRate2));
+
+        //when
+        ResultActions perform = mockMvc.perform(get("/shop/point-rate"));
+        perform
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.header.resultCode").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.header.resultMessage").value("SUCCESS"))
+                .andExpect(jsonPath("$.header.successful").value(true))
+                .andExpect(jsonPath("$.result.length()").value(2))
+                .andExpect(jsonPath("$.result[0].id").value(1))
+                .andExpect(jsonPath("$.result[0].name").value("테스트1"))
+                .andExpect(jsonPath("$.result[0].earnType").value("RATE"))
+                .andExpect(jsonPath("$.result[0].earnPoint").value(100));
+    }
+}

--- a/src/test/java/shop/bookbom/shop/domain/pointrate/controller/PointRateControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/pointrate/controller/PointRateControllerTest.java
@@ -1,11 +1,16 @@
 package shop.bookbom.shop.domain.pointrate.controller;
 
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import shop.bookbom.shop.domain.pointrate.dto.request.PointRateUpdateRequest;
 import shop.bookbom.shop.domain.pointrate.entity.EarnPointType;
 import shop.bookbom.shop.domain.pointrate.repository.dto.PointRateResponse;
 import shop.bookbom.shop.domain.pointrate.service.PointRateService;
@@ -27,6 +33,8 @@ import shop.bookbom.shop.domain.pointrate.service.PointRateService;
 class PointRateControllerTest {
     @Autowired
     MockMvc mockMvc;
+
+    ObjectMapper objectMapper = new ObjectMapper();
 
     @MockBean
     PointRateService pointRateService;
@@ -52,5 +60,44 @@ class PointRateControllerTest {
                 .andExpect(jsonPath("$.result[0].name").value("테스트1"))
                 .andExpect(jsonPath("$.result[0].earnType").value("RATE"))
                 .andExpect(jsonPath("$.result[0].earnPoint").value(100));
+    }
+
+    @Test
+    @DisplayName("포인트 적립 정책 수정")
+    void pointRateUpdate() throws Exception {
+        //given
+        PointRateResponse pointRate = new PointRateResponse(1L, "수정 테스트1", EarnPointType.COST, 100);
+        when(pointRateService.updatePolicy(anyLong(), anyString(), anyInt())).thenReturn(pointRate);
+        PointRateUpdateRequest request = new PointRateUpdateRequest("COST", 100);
+        //when
+        ResultActions perform = mockMvc.perform(put("/shop/point-rate/{id}", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+        perform
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.header.resultCode").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.header.resultMessage").value("SUCCESS"))
+                .andExpect(jsonPath("$.header.successful").value(true))
+                .andExpect(jsonPath("$.result.id").value(1))
+                .andExpect(jsonPath("$.result.name").value("수정 테스트1"))
+                .andExpect(jsonPath("$.result.earnType").value("COST"))
+                .andExpect(jsonPath("$.result.earnPoint").value(100));
+    }
+
+    @Test
+    @DisplayName("포인트 적립 정책 수정 예외")
+    void pointRateUpdateException() throws Exception {
+        //given
+        PointRateUpdateRequest request = new PointRateUpdateRequest("COST", 0);
+        //when
+        ResultActions perform = mockMvc.perform(put("/shop/point-rate/{id}", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+        perform
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.header.resultCode").value(400))
+                .andExpect(jsonPath("$.header.resultMessage").value("요청한 값이 올바르지 않습니다."))
+                .andExpect(jsonPath("$.header.successful").value(false));
     }
 }

--- a/src/test/java/shop/bookbom/shop/domain/pointrate/repository/PointRateRepositoryTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/pointrate/repository/PointRateRepositoryTest.java
@@ -44,11 +44,11 @@ class PointRateRepositoryTest {
 
         // when
         List<PointRateResponse> pointPolicies = pointRateRepository.getPointPolicies();
+        PointRateResponse response = pointPolicies.get(0);
 
         //then
-        PointRateResponse response = pointPolicies.get(0);
-        assertThat(response.getId()).isEqualTo(1L);
         assertThat(pointPolicies).hasSize(2);
+        assertThat(response.getId()).isEqualTo(1L);
         assertThat(response.getName()).isEqualTo("테스트1");
         assertThat(response.getEarnType()).isEqualTo(EarnPointType.COST);
         assertThat(response.getEarnPoint()).isEqualTo(100);

--- a/src/test/java/shop/bookbom/shop/domain/pointrate/repository/PointRateRepositoryTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/pointrate/repository/PointRateRepositoryTest.java
@@ -1,0 +1,56 @@
+package shop.bookbom.shop.domain.pointrate.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import shop.bookbom.shop.config.TestQuerydslConfig;
+import shop.bookbom.shop.domain.pointrate.entity.ApplyPointType;
+import shop.bookbom.shop.domain.pointrate.entity.EarnPointType;
+import shop.bookbom.shop.domain.pointrate.entity.PointRate;
+import shop.bookbom.shop.domain.pointrate.repository.dto.PointRateResponse;
+
+@Import(TestQuerydslConfig.class)
+@DataJpaTest
+class PointRateRepositoryTest {
+    @Autowired
+    PointRateRepository pointRateRepository;
+
+    @Test
+    @DisplayName("포인트 정책 조회")
+    void getPointPolicies() {
+        // given
+        PointRate pointRate1 = PointRate.builder()
+                .name("테스트1")
+                .earnType(EarnPointType.COST)
+                .earnPoint(100)
+                .applyType(ApplyPointType.BOOK)
+                .createdAt(LocalDateTime.now())
+                .build();
+        PointRate pointRate2 = PointRate.builder()
+                .name("테스트2")
+                .earnType(EarnPointType.RATE)
+                .earnPoint(300)
+                .applyType(ApplyPointType.RANK)
+                .createdAt(LocalDateTime.now())
+                .build();
+        pointRateRepository.save(pointRate1);
+        pointRateRepository.save(pointRate2);
+
+        // when
+        List<PointRateResponse> pointPolicies = pointRateRepository.getPointPolicies();
+
+        //then
+        PointRateResponse response = pointPolicies.get(0);
+        assertThat(response.getId()).isEqualTo(1L);
+        assertThat(pointPolicies).hasSize(2);
+        assertThat(response.getName()).isEqualTo("테스트1");
+        assertThat(response.getEarnType()).isEqualTo(EarnPointType.COST);
+        assertThat(response.getEarnPoint()).isEqualTo(100);
+    }
+}

--- a/src/test/java/shop/bookbom/shop/domain/pointrate/service/PointRateServiceTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/pointrate/service/PointRateServiceTest.java
@@ -1,0 +1,47 @@
+package shop.bookbom.shop.domain.pointrate.service;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import shop.bookbom.shop.domain.pointrate.entity.EarnPointType;
+import shop.bookbom.shop.domain.pointrate.repository.PointRateRepository;
+import shop.bookbom.shop.domain.pointrate.repository.dto.PointRateResponse;
+import shop.bookbom.shop.domain.pointrate.service.impl.PointRateServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+class PointRateServiceTest {
+
+    @Mock
+    PointRateRepository pointRateRepository;
+
+    @InjectMocks
+    PointRateServiceImpl pointRateService;
+
+    @Test
+    @DisplayName("포인트 목록 조회")
+    void getPointPolicies() {
+        //given
+        PointRateResponse pointRate1 = new PointRateResponse(1L, "테스트1", EarnPointType.RATE, 100);
+        PointRateResponse pointRate2 = new PointRateResponse(2L, "테스트2", EarnPointType.COST, 1000);
+        when(pointRateRepository.getPointPolicies()).thenReturn(List.of(pointRate1, pointRate2));
+
+        //when
+        List<PointRateResponse> result = pointRateService.getPointPolicies();
+        PointRateResponse response = result.get(0);
+
+        //then
+        assertThat(result).hasSize(2);
+        assertThat(response.getId()).isEqualTo(1L);
+        assertThat(response.getName()).isEqualTo("테스트1");
+        assertThat(response.getEarnType()).isEqualTo(EarnPointType.RATE);
+        assertThat(response.getEarnPoint()).isEqualTo(100);
+    }
+}

--- a/src/test/java/shop/bookbom/shop/domain/pointrate/service/PointRateServiceTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/pointrate/service/PointRateServiceTest.java
@@ -2,16 +2,21 @@ package shop.bookbom.shop.domain.pointrate.service;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import shop.bookbom.shop.domain.pointrate.entity.EarnPointType;
+import shop.bookbom.shop.domain.pointrate.entity.PointRate;
+import shop.bookbom.shop.domain.pointrate.exception.PointRateNotFoundException;
 import shop.bookbom.shop.domain.pointrate.repository.PointRateRepository;
 import shop.bookbom.shop.domain.pointrate.repository.dto.PointRateResponse;
 import shop.bookbom.shop.domain.pointrate.service.impl.PointRateServiceImpl;
@@ -43,5 +48,34 @@ class PointRateServiceTest {
         assertThat(response.getName()).isEqualTo("테스트1");
         assertThat(response.getEarnType()).isEqualTo(EarnPointType.RATE);
         assertThat(response.getEarnPoint()).isEqualTo(100);
+    }
+
+    @Test
+    @DisplayName("포인트 적립 정책 수정")
+    void updatePolicy() throws Exception {
+        //given
+        PointRate pointRate = PointRate.builder()
+                .name("테스트1")
+                .earnType(EarnPointType.RATE)
+                .earnPoint(100)
+                .build();
+        ReflectionTestUtils.setField(pointRate, "id", 1L);
+        when(pointRateRepository.findById(1L)).thenReturn(Optional.of(pointRate));
+        //when
+        PointRateResponse result = pointRateService.updatePolicy(1L, "COST", 200);
+
+        //then
+        assertThat(result.getEarnPoint()).isEqualTo(200);
+        assertThat(result.getEarnType()).isEqualTo(EarnPointType.COST);
+    }
+
+    @Test
+    @DisplayName("포인트 적립 정책 수정 예외")
+    void updatePolicyException() throws Exception {
+        //given
+        when(pointRateRepository.findById(1L)).thenReturn(Optional.empty());
+        //when & then
+        assertThatThrownBy(() -> pointRateService.updatePolicy(1L, "COST", 200))
+                .isInstanceOf(PointRateNotFoundException.class);
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:test;MODE=MySQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
# 설명
- 관리자 페이지에서 포인트 정책 목록을 조회하고 수정할 수 있도록 구현했습니다.

# 작업내용
- 포인트 정책 목록 조회, 수정 기능을 구현했습니다.
- 테스트 환경에 인메모리 H2를 적용했고, QueryDSL 환경 클래스 `TestQuerydslConfig`를 만들었습니다.
