### PR TITLE
[feat] 회원 마이페이지 기능 구현

### DIFF
--- a/src/main/java/shop/bookbom/shop/domain/member/controller/MemberController.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/controller/MemberController.java
@@ -1,0 +1,22 @@
+package shop.bookbom.shop.domain.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import shop.bookbom.shop.common.CommonResponse;
+import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
+import shop.bookbom.shop.domain.member.service.MemberService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/shop")
+public class MemberController {
+    private final MemberService memberService;
+
+    @GetMapping("/member/my-page")
+    public CommonResponse<MemberInfoResponse> myPage(@RequestParam("userId") Long id) {
+        return CommonResponse.successWithData(memberService.getMemberInfo(id));
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/dto/response/MemberInfoResponse.java
@@ -1,0 +1,38 @@
+package shop.bookbom.shop.domain.member.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import shop.bookbom.shop.domain.order.dto.response.OrderInfoResponse;
+
+@Getter
+public class MemberInfoResponse {
+    private Long id;
+    private String nickname;
+    private String rank;
+    private List<OrderInfoResponse> lastOrders;
+    private int point;
+    private long couponCount;
+    private long wishCount;
+
+    @Builder
+    @QueryProjection
+    public MemberInfoResponse(
+            Long id,
+            String nickname,
+            String rank,
+            List<OrderInfoResponse> lastOrders,
+            int point,
+            long couponCount,
+            long wishCount
+    ) {
+        this.id = id;
+        this.nickname = nickname;
+        this.rank = rank;
+        this.lastOrders = lastOrders;
+        this.point = point;
+        this.couponCount = couponCount;
+        this.wishCount = wishCount;
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/member/repository/MemberRepository.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/repository/MemberRepository.java
@@ -3,5 +3,5 @@ package shop.bookbom.shop.domain.member.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import shop.bookbom.shop.domain.member.entity.Member;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 }

--- a/src/main/java/shop/bookbom/shop/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/repository/MemberRepositoryCustom.java
@@ -1,0 +1,8 @@
+package shop.bookbom.shop.domain.member.repository;
+
+import java.util.Optional;
+import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
+
+public interface MemberRepositoryCustom {
+    Optional<MemberInfoResponse> findMemberInfo(Long id);
+}

--- a/src/main/java/shop/bookbom/shop/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/repository/MemberRepositoryCustom.java
@@ -1,8 +1,7 @@
 package shop.bookbom.shop.domain.member.repository;
 
-import java.util.Optional;
 import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
 
 public interface MemberRepositoryCustom {
-    Optional<MemberInfoResponse> findMemberInfo(Long id);
+    MemberInfoResponse findMemberInfo(Long id);
 }

--- a/src/main/java/shop/bookbom/shop/domain/member/repository/impl/MemberRepositoryImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/repository/impl/MemberRepositoryImpl.java
@@ -1,0 +1,65 @@
+package shop.bookbom.shop.domain.member.repository.impl;
+
+import static shop.bookbom.shop.domain.member.entity.QMember.member;
+import static shop.bookbom.shop.domain.membercoupon.entity.QMemberCoupon.memberCoupon;
+import static shop.bookbom.shop.domain.order.entity.QOrder.order;
+import static shop.bookbom.shop.domain.orderstatus.entity.QOrderStatus.orderStatus;
+import static shop.bookbom.shop.domain.rank.entity.QRank.rank;
+import static shop.bookbom.shop.domain.wish.entity.QWish.wish;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
+import shop.bookbom.shop.domain.member.entity.Member;
+import shop.bookbom.shop.domain.member.repository.MemberRepositoryCustom;
+import shop.bookbom.shop.domain.order.dto.response.OrderInfoResponse;
+
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<MemberInfoResponse> findMemberInfo(Long id) {
+        Member memberResult = queryFactory
+                .selectFrom(member)
+                .join(member.rank, rank).fetchJoin()
+                .leftJoin(member.orders, order).fetchJoin()
+                .leftJoin(order.status, orderStatus).fetchJoin()
+                .where(member.id.eq(id))
+                .fetchOne();
+
+        if (memberResult == null) {
+            return Optional.empty();
+        }
+
+        Long couponCount = queryFactory
+                .select(memberCoupon.count())
+                .from(memberCoupon)
+                .where(memberCoupon.member.eq(memberResult))
+                .fetchOne();
+
+        Long wishCount = queryFactory
+                .select(wish.count())
+                .from(wish)
+                .where(wish.member.eq(memberResult))
+                .fetchOne();
+
+        List<OrderInfoResponse> orders =
+                memberResult.getOrders().stream()
+                        .map(OrderInfoResponse::of)
+                        .collect(Collectors.toList());
+
+        return Optional.of(MemberInfoResponse.builder()
+                .id(memberResult.getId())
+                .nickname(memberResult.getNickname())
+                .rank(memberResult.getRank().getName())
+                .lastOrders(orders)
+                .point(memberResult.getPoint())
+                .couponCount((couponCount != null) ? couponCount : 0L)
+                .wishCount((wishCount != null) ? wishCount : 0L)
+                .build());
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/member/repository/impl/MemberRepositoryImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/repository/impl/MemberRepositoryImpl.java
@@ -10,11 +10,11 @@ import static shop.bookbom.shop.domain.wish.entity.QWish.wish;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
 import shop.bookbom.shop.domain.member.entity.Member;
+import shop.bookbom.shop.domain.member.exception.MemberNotFoundException;
 import shop.bookbom.shop.domain.member.repository.MemberRepositoryCustom;
 import shop.bookbom.shop.domain.order.dto.response.OrderInfoResponse;
 import shop.bookbom.shop.domain.order.entity.Order;
@@ -24,7 +24,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Optional<MemberInfoResponse> findMemberInfo(Long id) {
+    public MemberInfoResponse findMemberInfo(Long id) {
         Member memberResult = queryFactory
                 .selectFrom(member)
                 .join(member.rank, rank).fetchJoin()
@@ -34,7 +34,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .fetchOne();
 
         if (memberResult == null) {
-            return Optional.empty();
+            throw new MemberNotFoundException();
         }
 
         Long couponCount = queryFactory
@@ -56,7 +56,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                         .map(OrderInfoResponse::of)
                         .collect(Collectors.toList());
 
-        return Optional.of(MemberInfoResponse.builder()
+        return MemberInfoResponse.builder()
                 .id(memberResult.getId())
                 .nickname(memberResult.getNickname())
                 .rank(memberResult.getRank().getName())
@@ -64,6 +64,6 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .point(memberResult.getPoint())
                 .couponCount((couponCount != null) ? couponCount : 0L)
                 .wishCount((wishCount != null) ? wishCount : 0L)
-                .build());
+                .build();
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/member/repository/impl/MemberRepositoryImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/repository/impl/MemberRepositoryImpl.java
@@ -8,6 +8,7 @@ import static shop.bookbom.shop.domain.rank.entity.QRank.rank;
 import static shop.bookbom.shop.domain.wish.entity.QWish.wish;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -16,6 +17,7 @@ import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
 import shop.bookbom.shop.domain.member.entity.Member;
 import shop.bookbom.shop.domain.member.repository.MemberRepositoryCustom;
 import shop.bookbom.shop.domain.order.dto.response.OrderInfoResponse;
+import shop.bookbom.shop.domain.order.entity.Order;
 
 @RequiredArgsConstructor
 public class MemberRepositoryImpl implements MemberRepositoryCustom {
@@ -47,8 +49,10 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .where(wish.member.eq(memberResult))
                 .fetchOne();
 
-        List<OrderInfoResponse> orders =
+        List<OrderInfoResponse> lastOrders =
                 memberResult.getOrders().stream()
+                        .sorted(Comparator.comparing(Order::getOrderDate).reversed())
+                        .limit(5)
                         .map(OrderInfoResponse::of)
                         .collect(Collectors.toList());
 
@@ -56,7 +60,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .id(memberResult.getId())
                 .nickname(memberResult.getNickname())
                 .rank(memberResult.getRank().getName())
-                .lastOrders(orders)
+                .lastOrders(lastOrders)
                 .point(memberResult.getPoint())
                 .couponCount((couponCount != null) ? couponCount : 0L)
                 .wishCount((wishCount != null) ? wishCount : 0L)

--- a/src/main/java/shop/bookbom/shop/domain/member/service/MemberService.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/service/MemberService.java
@@ -1,0 +1,13 @@
+package shop.bookbom.shop.domain.member.service;
+
+import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
+
+public interface MemberService {
+    /**
+     * 마이페이지에 출력할 회원 정보를 가져오는 메서드입니다.
+     *
+     * @param id 회원 id
+     * @return 회원 정보
+     */
+    MemberInfoResponse getMemberInfo(Long id);
+}

--- a/src/main/java/shop/bookbom/shop/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/service/impl/MemberServiceImpl.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
-import shop.bookbom.shop.domain.member.exception.MemberNotFoundException;
 import shop.bookbom.shop.domain.member.repository.MemberRepository;
 import shop.bookbom.shop.domain.member.service.MemberService;
 
@@ -15,7 +14,6 @@ public class MemberServiceImpl implements MemberService {
 
     @Transactional(readOnly = true)
     public MemberInfoResponse getMemberInfo(Long id) {
-        return memberRepository.findMemberInfo(id)
-                .orElseThrow(MemberNotFoundException::new);
+        return memberRepository.findMemberInfo(id);
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/service/impl/MemberServiceImpl.java
@@ -1,0 +1,21 @@
+package shop.bookbom.shop.domain.member.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
+import shop.bookbom.shop.domain.member.exception.MemberNotFoundException;
+import shop.bookbom.shop.domain.member.repository.MemberRepository;
+import shop.bookbom.shop.domain.member.service.MemberService;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public MemberInfoResponse getMemberInfo(Long id) {
+        return memberRepository.findMemberInfo(id)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/order/dto/response/OrderInfoResponse.java
+++ b/src/main/java/shop/bookbom/shop/domain/order/dto/response/OrderInfoResponse.java
@@ -1,0 +1,29 @@
+package shop.bookbom.shop.domain.order.dto.response;
+
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import shop.bookbom.shop.domain.order.entity.Order;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderInfoResponse {
+    private Long id;
+    private LocalDate orderDate;
+    private String orderNumber;
+    private String name;
+    private int totalCost;
+    private String status;
+
+    public static OrderInfoResponse of(Order order) {
+        return new OrderInfoResponse(
+                order.getId(),
+                order.getOrderDate().toLocalDate(),
+                order.getOrderNumber(),
+                order.getOrderInfo(),
+                order.getTotalCost(),
+                order.getStatus().getName()
+        );
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/order/entity/Order.java
+++ b/src/main/java/shop/bookbom/shop/domain/order/entity/Order.java
@@ -17,6 +17,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import shop.bookbom.shop.domain.orderbook.entity.OrderBook;
 import shop.bookbom.shop.domain.orderstatus.entity.OrderStatus;
 import shop.bookbom.shop.domain.users.entity.User;
@@ -52,6 +53,7 @@ public class Order {
     @Column(name = "used_point", nullable = false)
     private int usedPoint;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;

--- a/src/main/java/shop/bookbom/shop/domain/users/entity/User.java
+++ b/src/main/java/shop/bookbom/shop/domain/users/entity/User.java
@@ -1,6 +1,8 @@
 package shop.bookbom.shop.domain.users.entity;
 
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -11,12 +13,14 @@ import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import shop.bookbom.shop.domain.order.entity.Order;
 import shop.bookbom.shop.domain.role.entity.Role;
 
 @Entity
@@ -45,6 +49,9 @@ public class User {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "role_id", nullable = false)
     private Role role;
+
+    @OneToMany(mappedBy = "user")
+    private List<Order> orders = new ArrayList<>();
 
     public User(
             String email,

--- a/src/main/java/shop/bookbom/shop/domain/users/entity/User.java
+++ b/src/main/java/shop/bookbom/shop/domain/users/entity/User.java
@@ -71,4 +71,12 @@ public class User {
     public void resetPassword(String password) {
         this.password = password;
     }
+
+    public void addOrder(Order order) {
+        if (orders == null) {
+            orders = new ArrayList<>();
+        }
+        orders.add(order);
+        order.setUser(this);
+    }
 }

--- a/src/test/java/shop/bookbom/shop/common/TestUtils.java
+++ b/src/test/java/shop/bookbom/shop/common/TestUtils.java
@@ -15,12 +15,16 @@ import shop.bookbom.shop.domain.cart.dto.request.CartUpdateRequest;
 import shop.bookbom.shop.domain.cart.entity.Cart;
 import shop.bookbom.shop.domain.member.entity.Member;
 import shop.bookbom.shop.domain.member.entity.MemberStatus;
+import shop.bookbom.shop.domain.order.entity.Order;
+import shop.bookbom.shop.domain.orderstatus.entity.OrderStatus;
 import shop.bookbom.shop.domain.pointrate.entity.ApplyPointType;
 import shop.bookbom.shop.domain.pointrate.entity.EarnPointType;
 import shop.bookbom.shop.domain.pointrate.entity.PointRate;
 import shop.bookbom.shop.domain.publisher.entity.Publisher;
 import shop.bookbom.shop.domain.rank.entity.Rank;
 import shop.bookbom.shop.domain.role.entity.Role;
+import shop.bookbom.shop.domain.users.entity.User;
+import shop.bookbom.shop.domain.wish.entity.Wish;
 
 public class TestUtils {
     private TestUtils() {
@@ -132,6 +136,33 @@ public class TestUtils {
     public static Publisher getPublisher() {
         return Publisher.builder()
                 .name("test")
+                .build();
+    }
+
+    public static Order getOrder(User user, OrderStatus orderStatus) {
+        return Order.builder()
+                .orderNumber("orderNumber")
+                .orderInfo("orderInfo")
+                .orderDate(LocalDateTime.now())
+                .senderName("senderName")
+                .senderPhoneNumber("senderPhoneNumber")
+                .totalCost(10000)
+                .usedPoint(0)
+                .user(user)
+                .status(orderStatus)
+                .build();
+    }
+
+    public static OrderStatus getOrderStatus() {
+        return OrderStatus.builder()
+                .name("test")
+                .build();
+    }
+
+    public static Wish getWish(Member member, Book book) {
+        return Wish.builder()
+                .member(member)
+                .book(book)
                 .build();
     }
 }

--- a/src/test/java/shop/bookbom/shop/common/TestUtils.java
+++ b/src/test/java/shop/bookbom/shop/common/TestUtils.java
@@ -13,6 +13,7 @@ import shop.bookbom.shop.domain.cart.dto.repsonse.CartUpdateResponse;
 import shop.bookbom.shop.domain.cart.dto.request.CartAddRequest;
 import shop.bookbom.shop.domain.cart.dto.request.CartUpdateRequest;
 import shop.bookbom.shop.domain.cart.entity.Cart;
+import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
 import shop.bookbom.shop.domain.member.entity.Member;
 import shop.bookbom.shop.domain.member.entity.MemberStatus;
 import shop.bookbom.shop.domain.order.entity.Order;
@@ -67,6 +68,7 @@ public class TestUtils {
                 .birthDate(LocalDate.now())
                 .registered(true)
                 .role(role)
+                .point(1000)
                 .status(MemberStatus.ACTIVE)
                 .rank(rank)
                 .build();
@@ -163,6 +165,16 @@ public class TestUtils {
         return Wish.builder()
                 .member(member)
                 .book(book)
+                .build();
+    }
+
+    public static MemberInfoResponse getMemberInfoResponse(Rank rank, Member member) {
+        return MemberInfoResponse.builder()
+                .rank(rank.getName())
+                .nickname(member.getNickname())
+                .point(member.getPoint())
+                .wishCount(2)
+                .couponCount(0)
                 .build();
     }
 }

--- a/src/test/java/shop/bookbom/shop/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,64 @@
+package shop.bookbom.shop.domain.member.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static shop.bookbom.shop.common.TestUtils.getMember;
+import static shop.bookbom.shop.common.TestUtils.getMemberInfoResponse;
+import static shop.bookbom.shop.common.TestUtils.getPointRate;
+import static shop.bookbom.shop.common.TestUtils.getRank;
+import static shop.bookbom.shop.common.TestUtils.getRole;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import shop.bookbom.shop.domain.member.service.MemberService;
+import shop.bookbom.shop.domain.rank.entity.Rank;
+
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockBean
+    MemberService memberService;
+
+    @Test
+    @DisplayName("마이 페이지")
+    void myPage() throws Exception {
+        //given
+        Rank rank = getRank(getPointRate());
+        when(memberService.getMemberInfo(1L)).thenReturn(
+                getMemberInfoResponse(rank, getMember("test@email.com", getRole(), rank)));
+        //when
+        ResultActions perform = mockMvc.perform(get("/shop/member/my-page")
+                .param("userId", "1"));
+
+        //then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.header.resultCode").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.header.resultMessage").value("SUCCESS"))
+                .andExpect(jsonPath("$.header.successful").value(true))
+                .andExpect(jsonPath("$.result.nickname").value("test"))
+                .andExpect(jsonPath("$.result.rank").value("test"))
+                .andExpect(jsonPath("$.result.point").value(1000))
+                .andExpect(jsonPath("$.result.couponCount").value(0))
+                .andExpect(jsonPath("$.result.wishCount").value(2));
+    }
+}

--- a/src/test/java/shop/bookbom/shop/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,80 @@
+package shop.bookbom.shop.domain.member.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static shop.bookbom.shop.common.TestUtils.getBook;
+import static shop.bookbom.shop.common.TestUtils.getMember;
+import static shop.bookbom.shop.common.TestUtils.getOrder;
+import static shop.bookbom.shop.common.TestUtils.getOrderStatus;
+import static shop.bookbom.shop.common.TestUtils.getPointRate;
+import static shop.bookbom.shop.common.TestUtils.getPublisher;
+import static shop.bookbom.shop.common.TestUtils.getRank;
+import static shop.bookbom.shop.common.TestUtils.getRole;
+import static shop.bookbom.shop.common.TestUtils.getWish;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import shop.bookbom.shop.config.TestQuerydslConfig;
+import shop.bookbom.shop.domain.book.entity.Book;
+import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
+import shop.bookbom.shop.domain.member.entity.Member;
+import shop.bookbom.shop.domain.order.entity.Order;
+import shop.bookbom.shop.domain.orderstatus.entity.OrderStatus;
+import shop.bookbom.shop.domain.pointrate.entity.PointRate;
+import shop.bookbom.shop.domain.publisher.entity.Publisher;
+import shop.bookbom.shop.domain.rank.entity.Rank;
+import shop.bookbom.shop.domain.role.entity.Role;
+import shop.bookbom.shop.domain.wish.entity.Wish;
+
+@Import(TestQuerydslConfig.class)
+@DataJpaTest
+class MemberRepositoryTest {
+    @Autowired
+    TestEntityManager em;
+    @Autowired
+    private MemberRepository memberRepository;
+
+
+    @Test
+    @DisplayName("마이 페이지 회원 정보 조회")
+    void findMemberInfo() throws Exception {
+        Role role = em.persist(getRole());
+        PointRate pointRate = em.persist(getPointRate());
+        Rank rank = em.persist(getRank(pointRate));
+        OrderStatus orderStatus = em.persist(getOrderStatus());
+        Member member = em.persist(getMember("email@email.com", role, rank));
+        Order order1 = em.persist(getOrder(member, orderStatus));
+        Order order2 = em.persist(getOrder(member, orderStatus));
+        member.addOrder(order1);
+        member.addOrder(order2);
+        Publisher publisher = em.persist(getPublisher());
+        Book book1 = em.persist(getBook("title1", pointRate, publisher));
+        Book book2 = em.persist(getBook("title2", pointRate, publisher));
+        Wish wish1 = em.persist(getWish(member, book1));
+        Wish wish2 = em.persist(getWish(member, book2));
+        //when
+        MemberInfoResponse response =
+                memberRepository.findMemberInfo(member.getId())
+                        .orElseThrow(NullPointerException::new);
+        //then
+        assertThat(response.getRank()).isEqualTo(rank.getName());
+        assertThat(response.getNickname()).isEqualTo(member.getNickname());
+        assertThat(response.getPoint()).isEqualTo(member.getPoint());
+        assertThat(response.getLastOrders()).hasSize(2);
+        assertThat(response.getWishCount()).isEqualTo(2);
+        assertThat(response.getCouponCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원 정보 요청")
+    void findNoneMemberInfo() throws Exception {
+        //when
+        Optional<MemberInfoResponse> response = memberRepository.findMemberInfo(1L);
+        //then
+        assertThat(response).isEmpty();
+    }
+}

--- a/src/test/java/shop/bookbom/shop/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/member/repository/MemberRepositoryTest.java
@@ -28,7 +28,6 @@ import shop.bookbom.shop.domain.pointrate.entity.PointRate;
 import shop.bookbom.shop.domain.publisher.entity.Publisher;
 import shop.bookbom.shop.domain.rank.entity.Rank;
 import shop.bookbom.shop.domain.role.entity.Role;
-import shop.bookbom.shop.domain.wish.entity.Wish;
 
 @Import(TestQuerydslConfig.class)
 @DataJpaTest
@@ -41,7 +40,7 @@ class MemberRepositoryTest {
 
     @Test
     @DisplayName("마이 페이지 회원 정보 조회")
-    void findMemberInfo() throws Exception {
+    void findMemberInfo() {
         Role role = em.persist(getRole());
         PointRate pointRate = em.persist(getPointRate());
         Rank rank = em.persist(getRank(pointRate));
@@ -54,8 +53,8 @@ class MemberRepositoryTest {
         Publisher publisher = em.persist(getPublisher());
         Book book1 = em.persist(getBook("title1", pointRate, publisher));
         Book book2 = em.persist(getBook("title2", pointRate, publisher));
-        Wish wish1 = em.persist(getWish(member, book1));
-        Wish wish2 = em.persist(getWish(member, book2));
+        em.persist(getWish(member, book1));
+        em.persist(getWish(member, book2));
         //when
         MemberInfoResponse response =
                 memberRepository.findMemberInfo(member.getId())
@@ -71,7 +70,7 @@ class MemberRepositoryTest {
 
     @Test
     @DisplayName("존재하지 않는 회원 정보 요청")
-    void findNoneMemberInfo() throws Exception {
+    void findNoneMemberInfo() {
         //when
         Optional<MemberInfoResponse> response = memberRepository.findMemberInfo(1L);
         //then

--- a/src/test/java/shop/bookbom/shop/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/member/repository/MemberRepositoryTest.java
@@ -1,6 +1,7 @@
 package shop.bookbom.shop.domain.member.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static shop.bookbom.shop.common.TestUtils.getBook;
 import static shop.bookbom.shop.common.TestUtils.getMember;
 import static shop.bookbom.shop.common.TestUtils.getOrder;
@@ -11,7 +12,6 @@ import static shop.bookbom.shop.common.TestUtils.getRank;
 import static shop.bookbom.shop.common.TestUtils.getRole;
 import static shop.bookbom.shop.common.TestUtils.getWish;
 
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +22,7 @@ import shop.bookbom.shop.config.TestQuerydslConfig;
 import shop.bookbom.shop.domain.book.entity.Book;
 import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
 import shop.bookbom.shop.domain.member.entity.Member;
+import shop.bookbom.shop.domain.member.exception.MemberNotFoundException;
 import shop.bookbom.shop.domain.order.entity.Order;
 import shop.bookbom.shop.domain.orderstatus.entity.OrderStatus;
 import shop.bookbom.shop.domain.pointrate.entity.PointRate;
@@ -56,9 +57,7 @@ class MemberRepositoryTest {
         em.persist(getWish(member, book1));
         em.persist(getWish(member, book2));
         //when
-        MemberInfoResponse response =
-                memberRepository.findMemberInfo(member.getId())
-                        .orElseThrow(NullPointerException::new);
+        MemberInfoResponse response = memberRepository.findMemberInfo(member.getId());
         //then
         assertThat(response.getRank()).isEqualTo(rank.getName());
         assertThat(response.getNickname()).isEqualTo(member.getNickname());
@@ -71,9 +70,8 @@ class MemberRepositoryTest {
     @Test
     @DisplayName("존재하지 않는 회원 정보 요청")
     void findNoneMemberInfo() {
-        //when
-        Optional<MemberInfoResponse> response = memberRepository.findMemberInfo(1L);
-        //then
-        assertThat(response).isEmpty();
+        //when & then
+        assertThatThrownBy(() -> memberRepository.findMemberInfo(1L))
+                .isInstanceOf(MemberNotFoundException.class);
     }
 }

--- a/src/test/java/shop/bookbom/shop/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/member/service/MemberServiceTest.java
@@ -1,7 +1,6 @@
 package shop.bookbom.shop.domain.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static shop.bookbom.shop.common.TestUtils.getMember;
@@ -12,7 +11,6 @@ import static shop.bookbom.shop.common.TestUtils.getPointRate;
 import static shop.bookbom.shop.common.TestUtils.getRank;
 import static shop.bookbom.shop.common.TestUtils.getRole;
 
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,7 +19,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
 import shop.bookbom.shop.domain.member.entity.Member;
-import shop.bookbom.shop.domain.member.exception.MemberNotFoundException;
 import shop.bookbom.shop.domain.member.repository.MemberRepository;
 import shop.bookbom.shop.domain.member.service.impl.MemberServiceImpl;
 import shop.bookbom.shop.domain.rank.entity.Rank;
@@ -43,8 +40,7 @@ class MemberServiceTest {
         member.addOrder(getOrder(member, getOrderStatus()));
         MemberInfoResponse response =
                 getMemberInfoResponse(rank, member);
-        when(memberRepository.findMemberInfo(any()))
-                .thenReturn(Optional.of(response));
+        when(memberRepository.findMemberInfo(any())).thenReturn(response);
         //when
         MemberInfoResponse memberInfo = memberService.getMemberInfo(1L);
 
@@ -55,16 +51,5 @@ class MemberServiceTest {
         assertThat(memberInfo.getPoint()).isEqualTo(1000);
         assertThat(memberInfo.getCouponCount()).isZero();
         assertThat(memberInfo.getWishCount()).isEqualTo(2);
-    }
-
-    @Test
-    @DisplayName("마이 페이지 없는 회원 정보 조회")
-    void getNoneMemberInfo() {
-        //given
-        when(memberRepository.findMemberInfo(any()))
-                .thenReturn(Optional.empty());
-        //when & then
-        assertThatThrownBy(() -> memberService.getMemberInfo(1L))
-                .isInstanceOf(MemberNotFoundException.class);
     }
 }

--- a/src/test/java/shop/bookbom/shop/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,70 @@
+package shop.bookbom.shop.domain.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static shop.bookbom.shop.common.TestUtils.getMember;
+import static shop.bookbom.shop.common.TestUtils.getMemberInfoResponse;
+import static shop.bookbom.shop.common.TestUtils.getOrder;
+import static shop.bookbom.shop.common.TestUtils.getOrderStatus;
+import static shop.bookbom.shop.common.TestUtils.getPointRate;
+import static shop.bookbom.shop.common.TestUtils.getRank;
+import static shop.bookbom.shop.common.TestUtils.getRole;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
+import shop.bookbom.shop.domain.member.entity.Member;
+import shop.bookbom.shop.domain.member.exception.MemberNotFoundException;
+import shop.bookbom.shop.domain.member.repository.MemberRepository;
+import shop.bookbom.shop.domain.member.service.impl.MemberServiceImpl;
+import shop.bookbom.shop.domain.rank.entity.Rank;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @InjectMocks
+    MemberServiceImpl memberService;
+    @Mock
+    MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("마이 페이지 회원 정보 조회")
+    void getMemberInfo() {
+        //given
+        Rank rank = getRank(getPointRate());
+        Member member = getMember("test@email.com", getRole(), rank);
+        member.addOrder(getOrder(member, getOrderStatus()));
+        MemberInfoResponse response =
+                getMemberInfoResponse(rank, member);
+        when(memberRepository.findMemberInfo(any()))
+                .thenReturn(Optional.of(response));
+        //when
+        MemberInfoResponse memberInfo = memberService.getMemberInfo(1L);
+
+        //then
+        assertThat(memberInfo).isNotNull();
+        assertThat(memberInfo.getNickname()).isEqualTo("test");
+        assertThat(memberInfo.getRank()).isEqualTo("test");
+        assertThat(memberInfo.getPoint()).isEqualTo(1000);
+        assertThat(memberInfo.getCouponCount()).isZero();
+        assertThat(memberInfo.getWishCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("마이 페이지 없는 회원 정보 조회")
+    void getNoneMemberInfo() {
+        //given
+        when(memberRepository.findMemberInfo(any()))
+                .thenReturn(Optional.empty());
+        //when & then
+        assertThatThrownBy(() -> memberService.getMemberInfo(1L))
+                .isInstanceOf(MemberNotFoundException.class);
+    }
+}


### PR DESCRIPTION
# 설명
- 마이페이지 회원 정보 API를 구현하였습니다.

# 작업내용
- 회원 닉네임, 등급,  최근 주문 내역, 쿠폰 갯수, 찜 갯수, 포인트 를 가져옵니다.
- 최근 주문 내역은 주문일 기준 5개만 가져옵니다.