### PR TITLE
[fix] 포인트 변경 내역 ERD 수정

### DIFF
--- a/src/main/java/shop/bookbom/shop/domain/pointhistory/entity/ChangeReason.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointhistory/entity/ChangeReason.java
@@ -1,0 +1,16 @@
+package shop.bookbom.shop.domain.pointhistory.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum ChangeReason {
+    EARN("적립"),
+    USE("사용"),
+    ;
+
+    private final String value;
+
+    ChangeReason(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/pointhistory/entity/PointHistory.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointhistory/entity/PointHistory.java
@@ -25,13 +25,16 @@ public class PointHistory {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "point_history_id", nullable = false)
-    private Long pointHistoryId;
+    private Long id;
 
     @Column(name = "change_point", nullable = false)
     private int changePoint;
 
     @Column(name = "change_reason", nullable = false, length = 50)
-    private String changeReason;
+    private ChangeReason changeReason;
+
+    @Column(name = "detail", nullable = false, length = 100)
+    private PointHistoryDetail detail;
 
     @Column(name = "change_date", nullable = false)
     private LocalDateTime changeDate;
@@ -43,7 +46,7 @@ public class PointHistory {
     @Builder
     public PointHistory(
             int changePoint,
-            String changeReason,
+            ChangeReason changeReason,
             LocalDateTime changeDate,
             Member member
     ) {

--- a/src/main/java/shop/bookbom/shop/domain/pointhistory/entity/PointHistoryDetail.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointhistory/entity/PointHistoryDetail.java
@@ -1,0 +1,17 @@
+package shop.bookbom.shop.domain.pointhistory.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum PointHistoryDetail {
+    ORDER_EARN("주문 적립"),
+    PAYMENT_USE("적립금 결제"),
+    REVIEW("리뷰 적립"),
+    ;
+
+    private final String value;
+
+    PointHistoryDetail(String value) {
+        this.value = value;
+    }
+}


### PR DESCRIPTION
# 설명
- 포인트 변경 내역 PointHistory 에 수정사항을 반영했습니다.

# 작업내용
- 적립/사용 내역 내용을 담는 `detail` 필드를 추가하였습니다. (ex. 리뷰 적립, 주문 적립)
- 변경 사유 `changeReason`과 `detail`을 ENUM으로 만들었습니다.

![image](https://github.com/nhnacademy-be5-bom/bookbom-shop/assets/95916780/779c9b7a-832c-4144-b5af-58523f19a4b7)

