### PR TITLE
[feat] 회원 포인트 적립/사용 내역 조회 기능 구현

### DIFF
--- a/src/main/java/shop/bookbom/shop/common/exception/ErrorCode.java
+++ b/src/main/java/shop/bookbom/shop/common/exception/ErrorCode.java
@@ -43,7 +43,9 @@ public enum ErrorCode {
     // author
     AUTHOR_ID_NOT_FOUND(404, "일치하는 작가 ID가 없습니다."),
     // point_rate
-    POINT_RATE_NOT_FOUND(400,"해당 포인트 정책이 존재하지 않습니다."),
+    POINT_RATE_NOT_FOUND(400, "해당 포인트 정책이 존재하지 않습니다."),
+    // point_history
+    POINT_INVALID_REASON(400, "요청하신 포인트 변동사유가 올바르지 않습니다."),
     ;
 
     private final int code;

--- a/src/main/java/shop/bookbom/shop/domain/pointhistory/controller/PointHistoryController.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointhistory/controller/PointHistoryController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import shop.bookbom.shop.common.CommonResponse;
@@ -17,6 +18,7 @@ import shop.bookbom.shop.domain.pointhistory.service.PointHistoryService;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/shop")
 public class PointHistoryController {
     private final PointHistoryService pointHistoryService;
 
@@ -33,7 +35,7 @@ public class PointHistoryController {
                 .orElseThrow(InvalidChangeReasonException::new);
     }
 
-    @GetMapping("/point-history")
+    @GetMapping("/member/point-history")
     public CommonResponse<Page<PointHistoryResponse>> getPointHistory(
             @RequestParam Long userId,
             Pageable pageable,

--- a/src/main/java/shop/bookbom/shop/domain/pointhistory/controller/PointHistoryController.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointhistory/controller/PointHistoryController.java
@@ -1,0 +1,47 @@
+package shop.bookbom.shop.domain.pointhistory.controller;
+
+import static shop.bookbom.shop.common.CommonResponse.successWithData;
+
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import shop.bookbom.shop.common.CommonResponse;
+import shop.bookbom.shop.domain.pointhistory.dto.response.PointHistoryResponse;
+import shop.bookbom.shop.domain.pointhistory.entity.ChangeReason;
+import shop.bookbom.shop.domain.pointhistory.exception.InvalidChangeReasonException;
+import shop.bookbom.shop.domain.pointhistory.service.PointHistoryService;
+
+@RestController
+@RequiredArgsConstructor
+public class PointHistoryController {
+    private final PointHistoryService pointHistoryService;
+
+    /**
+     * 파라미터로 온 reason을 ChangeReason으로 변환하는 메서드입니다.
+     *
+     * @param changeReason 포인트 변동 사유
+     * @return ChangeReason
+     */
+    private static ChangeReason getChangeReason(String changeReason) {
+        return Arrays.stream(ChangeReason.values())
+                .filter(it -> it.name().equals(changeReason))
+                .findFirst()
+                .orElseThrow(InvalidChangeReasonException::new);
+    }
+
+    @GetMapping("/point-history")
+    public CommonResponse<Page<PointHistoryResponse>> getPointHistory(
+            @RequestParam Long userId,
+            Pageable pageable,
+            @RequestParam(value = "reason", required = false) String reason
+    ) {
+        if (reason == null) {
+            return successWithData(pointHistoryService.findPointHistory(userId, pageable, null));
+        }
+        return successWithData(pointHistoryService.findPointHistory(userId, pageable, getChangeReason(reason)));
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/pointhistory/dto/response/PointHistoryResponse.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointhistory/dto/response/PointHistoryResponse.java
@@ -1,0 +1,31 @@
+package shop.bookbom.shop.domain.pointhistory.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PointHistoryResponse {
+    private Long id;
+    private String reason;
+    private String detail;
+    private int changePoint;
+    private LocalDateTime changeDate;
+
+    @Builder
+    @QueryProjection
+    public PointHistoryResponse(
+            Long id,
+            String reason,
+            String detail,
+            int changePoint,
+            LocalDateTime changeDate
+    ) {
+        this.id = id;
+        this.reason = reason;
+        this.detail = detail;
+        this.changePoint = changePoint;
+        this.changeDate = changeDate;
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/pointhistory/exception/InvalidChangeReasonException.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointhistory/exception/InvalidChangeReasonException.java
@@ -1,0 +1,10 @@
+package shop.bookbom.shop.domain.pointhistory.exception;
+
+import shop.bookbom.shop.common.exception.BaseException;
+import shop.bookbom.shop.common.exception.ErrorCode;
+
+public class InvalidChangeReasonException extends BaseException {
+    public InvalidChangeReasonException() {
+        super(ErrorCode.POINT_INVALID_REASON);
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/pointhistory/repository/PointHistoryRepository.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointhistory/repository/PointHistoryRepository.java
@@ -1,0 +1,7 @@
+package shop.bookbom.shop.domain.pointhistory.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shop.bookbom.shop.domain.pointhistory.entity.PointHistory;
+
+public interface PointHistoryRepository extends JpaRepository<PointHistory, Long>, PointHistoryRepositoryCustom {
+}

--- a/src/main/java/shop/bookbom/shop/domain/pointhistory/repository/PointHistoryRepositoryCustom.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointhistory/repository/PointHistoryRepositoryCustom.java
@@ -1,0 +1,19 @@
+package shop.bookbom.shop.domain.pointhistory.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import shop.bookbom.shop.domain.member.entity.Member;
+import shop.bookbom.shop.domain.pointhistory.dto.response.PointHistoryResponse;
+import shop.bookbom.shop.domain.pointhistory.entity.ChangeReason;
+
+public interface PointHistoryRepositoryCustom {
+    /**
+     * 회원의 포인트 적립/사용 내역을 조회하는 메서드입니다.
+     *
+     * @param member       회원 정보
+     * @param pageable     페이지 정보
+     * @param changeReason 변동사유 필터링 (ex. 적립 / 사용)
+     * @return 포인트 적립/사용 내역
+     */
+    Page<PointHistoryResponse> getPointHistory(Member member, Pageable pageable, ChangeReason changeReason);
+}

--- a/src/main/java/shop/bookbom/shop/domain/pointhistory/repository/impl/PointHistoryRepositoryImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointhistory/repository/impl/PointHistoryRepositoryImpl.java
@@ -1,0 +1,59 @@
+package shop.bookbom.shop.domain.pointhistory.repository.impl;
+
+import static shop.bookbom.shop.domain.member.entity.QMember.member;
+import static shop.bookbom.shop.domain.pointhistory.entity.QPointHistory.pointHistory;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import shop.bookbom.shop.domain.member.entity.Member;
+import shop.bookbom.shop.domain.pointhistory.dto.response.PointHistoryResponse;
+import shop.bookbom.shop.domain.pointhistory.dto.response.QPointHistoryResponse;
+import shop.bookbom.shop.domain.pointhistory.entity.ChangeReason;
+import shop.bookbom.shop.domain.pointhistory.repository.PointHistoryRepositoryCustom;
+
+@RequiredArgsConstructor
+public class PointHistoryRepositoryImpl implements PointHistoryRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<PointHistoryResponse> getPointHistory(Member mem, Pageable pageable, ChangeReason changeReason) {
+        List<PointHistoryResponse> content = queryFactory
+                .select(new QPointHistoryResponse(
+                        pointHistory.id,
+                        pointHistory.changeReason.stringValue(),
+                        pointHistory.detail.stringValue(),
+                        pointHistory.changePoint,
+                        pointHistory.changeDate
+                ))
+                .from(pointHistory)
+                .leftJoin(pointHistory.member, member)
+                .where(
+                        pointHistory.member.eq(mem),
+                        changeReasonEq(changeReason)
+                )
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(pointHistory.count())
+                .from(pointHistory)
+                .leftJoin(pointHistory.member, member)
+                .where(
+                        pointHistory.member.eq(mem),
+                        changeReasonEq(changeReason)
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression changeReasonEq(ChangeReason changeReason) {
+        return changeReason != null ? pointHistory.changeReason.eq(ChangeReason.valueOf(changeReason.name())) : null;
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/pointhistory/service/PointHistoryService.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointhistory/service/PointHistoryService.java
@@ -1,0 +1,10 @@
+package shop.bookbom.shop.domain.pointhistory.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import shop.bookbom.shop.domain.pointhistory.dto.response.PointHistoryResponse;
+import shop.bookbom.shop.domain.pointhistory.entity.ChangeReason;
+
+public interface PointHistoryService {
+    Page<PointHistoryResponse> findPointHistory(Long memberId, Pageable pageable, ChangeReason changeReason);
+}

--- a/src/main/java/shop/bookbom/shop/domain/pointhistory/service/impl/PointHistoryServiceImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointhistory/service/impl/PointHistoryServiceImpl.java
@@ -1,0 +1,29 @@
+package shop.bookbom.shop.domain.pointhistory.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.bookbom.shop.domain.member.entity.Member;
+import shop.bookbom.shop.domain.member.exception.MemberNotFoundException;
+import shop.bookbom.shop.domain.member.repository.MemberRepository;
+import shop.bookbom.shop.domain.pointhistory.dto.response.PointHistoryResponse;
+import shop.bookbom.shop.domain.pointhistory.entity.ChangeReason;
+import shop.bookbom.shop.domain.pointhistory.repository.PointHistoryRepository;
+import shop.bookbom.shop.domain.pointhistory.service.PointHistoryService;
+
+@Service
+@RequiredArgsConstructor
+public class PointHistoryServiceImpl implements PointHistoryService {
+    private final MemberRepository memberRepository;
+    private final PointHistoryRepository pointHistoryRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<PointHistoryResponse> findPointHistory(Long memberId, Pageable pageable, ChangeReason changeReason) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+        return pointHistoryRepository.getPointHistory(member, pageable, changeReason);
+    }
+}

--- a/src/test/java/shop/bookbom/shop/common/TestUtils.java
+++ b/src/test/java/shop/bookbom/shop/common/TestUtils.java
@@ -15,6 +15,7 @@ import shop.bookbom.shop.domain.cart.dto.request.CartUpdateRequest;
 import shop.bookbom.shop.domain.cart.entity.Cart;
 import shop.bookbom.shop.domain.member.entity.Member;
 import shop.bookbom.shop.domain.member.entity.MemberStatus;
+import shop.bookbom.shop.domain.pointhistory.dto.response.PointHistoryResponse;
 import shop.bookbom.shop.domain.pointhistory.entity.ChangeReason;
 import shop.bookbom.shop.domain.pointhistory.entity.PointHistory;
 import shop.bookbom.shop.domain.pointhistory.entity.PointHistoryDetail;
@@ -145,6 +146,16 @@ public class TestUtils {
                 .changeReason(changeReason)
                 .detail(PointHistoryDetail.ORDER_EARN)
                 .changeDate(LocalDateTime.now())
+                .build();
+    }
+
+    public static PointHistoryResponse getPointHistoryResponse() {
+        return PointHistoryResponse.builder()
+                .id(1L)
+                .reason(ChangeReason.USE.name())
+                .changeDate(LocalDateTime.now())
+                .detail(PointHistoryDetail.ORDER_EARN.name())
+                .changePoint(1000)
                 .build();
     }
 }

--- a/src/test/java/shop/bookbom/shop/common/TestUtils.java
+++ b/src/test/java/shop/bookbom/shop/common/TestUtils.java
@@ -149,10 +149,10 @@ public class TestUtils {
                 .build();
     }
 
-    public static PointHistoryResponse getPointHistoryResponse() {
+    public static PointHistoryResponse getPointHistoryResponse(ChangeReason changeReason) {
         return PointHistoryResponse.builder()
                 .id(1L)
-                .reason(ChangeReason.USE.name())
+                .reason(changeReason.name())
                 .changeDate(LocalDateTime.now())
                 .detail(PointHistoryDetail.ORDER_EARN.name())
                 .changePoint(1000)

--- a/src/test/java/shop/bookbom/shop/common/TestUtils.java
+++ b/src/test/java/shop/bookbom/shop/common/TestUtils.java
@@ -15,6 +15,9 @@ import shop.bookbom.shop.domain.cart.dto.request.CartUpdateRequest;
 import shop.bookbom.shop.domain.cart.entity.Cart;
 import shop.bookbom.shop.domain.member.entity.Member;
 import shop.bookbom.shop.domain.member.entity.MemberStatus;
+import shop.bookbom.shop.domain.pointhistory.entity.ChangeReason;
+import shop.bookbom.shop.domain.pointhistory.entity.PointHistory;
+import shop.bookbom.shop.domain.pointhistory.entity.PointHistoryDetail;
 import shop.bookbom.shop.domain.pointrate.entity.ApplyPointType;
 import shop.bookbom.shop.domain.pointrate.entity.EarnPointType;
 import shop.bookbom.shop.domain.pointrate.entity.PointRate;
@@ -132,6 +135,16 @@ public class TestUtils {
     public static Publisher getPublisher() {
         return Publisher.builder()
                 .name("test")
+                .build();
+    }
+
+    public static PointHistory getPointHistory(Member member, ChangeReason changeReason) {
+        return PointHistory.builder()
+                .member(member)
+                .changePoint(100)
+                .changeReason(changeReason)
+                .detail(PointHistoryDetail.ORDER_EARN)
+                .changeDate(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/test/java/shop/bookbom/shop/domain/pointhistory/controller/PointHistoryControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/pointhistory/controller/PointHistoryControllerTest.java
@@ -1,0 +1,98 @@
+package shop.bookbom.shop.domain.pointhistory.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static shop.bookbom.shop.common.TestUtils.getPointHistoryResponse;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import shop.bookbom.shop.domain.pointhistory.dto.response.PointHistoryResponse;
+import shop.bookbom.shop.domain.pointhistory.entity.ChangeReason;
+import shop.bookbom.shop.domain.pointhistory.service.PointHistoryService;
+
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest(PointHistoryController.class)
+class PointHistoryControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    PointHistoryService pointHistoryService;
+
+    @Test
+    @DisplayName("포인트 내역 조회")
+    void getPointHistory() throws Exception {
+        PointHistoryResponse pointHistoryResponse = getPointHistoryResponse(ChangeReason.EARN);
+        PageRequest pageRequest = PageRequest.of(0, 5);
+        PageImpl<PointHistoryResponse> page = new PageImpl<>(List.of(pointHistoryResponse), pageRequest, 1);
+        when(pointHistoryService.findPointHistory(any(), any(), any())).thenReturn(page);
+        ResultActions perform = mockMvc.perform(get("/shop/member/point-history")
+                .param("userId", "1"));
+        perform
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.header.resultCode").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.header.resultMessage").value("SUCCESS"))
+                .andExpect(jsonPath("$.header.successful").value(true))
+                .andExpect(jsonPath("$.result.content.size()").value(1))
+                .andExpect(jsonPath("$.result.content[0].reason").value(ChangeReason.EARN.name()))
+                .andExpect(jsonPath("$.result.content[0].changePoint").value(1000));
+    }
+
+    @Test
+    @DisplayName("필터링 조건 포함한 포인트 내역 조회")
+    void getPointHistoryContainsReason() throws Exception {
+        PointHistoryResponse pointHistoryResponse = getPointHistoryResponse(ChangeReason.EARN);
+        PageRequest pageRequest = PageRequest.of(0, 5);
+        PageImpl<PointHistoryResponse> page = new PageImpl<>(List.of(pointHistoryResponse), pageRequest, 1);
+        when(pointHistoryService.findPointHistory(any(), any(), eq(ChangeReason.EARN))).thenReturn(page);
+        when(pointHistoryService.findPointHistory(any(), any(), eq(ChangeReason.USE))).thenReturn(Page.empty());
+        ResultActions perform = mockMvc.perform(get("/shop/member/point-history")
+                .param("userId", "1")
+                .param("reason", "USE"));
+        perform
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.header.resultCode").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.header.resultMessage").value("SUCCESS"))
+                .andExpect(jsonPath("$.header.successful").value(true))
+                .andExpect(jsonPath("$.result.content.size()").value(0));
+    }
+
+    @Test
+    @DisplayName("올바르지 않은 포인트 내역 조회")
+    void pointHistoryInvalidReason() throws Exception {
+        PointHistoryResponse pointHistoryResponse = getPointHistoryResponse(ChangeReason.EARN);
+        PageRequest pageRequest = PageRequest.of(0, 5);
+        PageImpl<PointHistoryResponse> page = new PageImpl<>(List.of(pointHistoryResponse), pageRequest, 1);
+        when(pointHistoryService.findPointHistory(any(), any(), any())).thenReturn(page);
+        ResultActions perform = mockMvc.perform(get("/shop/member/point-history")
+                .param("userId", "1")
+                .param("reason", "TESTTT"));
+        perform
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.header.resultCode").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.header.resultMessage").value("요청하신 포인트 변동사유가 올바르지 않습니다."))
+                .andExpect(jsonPath("$.header.successful").value(false));
+    }
+}

--- a/src/test/java/shop/bookbom/shop/domain/pointhistory/repository/PointHistoryRepositoryTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/pointhistory/repository/PointHistoryRepositoryTest.java
@@ -1,0 +1,87 @@
+package shop.bookbom.shop.domain.pointhistory.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static shop.bookbom.shop.common.TestUtils.getMember;
+import static shop.bookbom.shop.common.TestUtils.getPointHistory;
+import static shop.bookbom.shop.common.TestUtils.getPointRate;
+import static shop.bookbom.shop.common.TestUtils.getRank;
+import static shop.bookbom.shop.common.TestUtils.getRole;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import shop.bookbom.shop.config.TestQuerydslConfig;
+import shop.bookbom.shop.domain.member.entity.Member;
+import shop.bookbom.shop.domain.pointhistory.dto.response.PointHistoryResponse;
+import shop.bookbom.shop.domain.pointhistory.entity.ChangeReason;
+import shop.bookbom.shop.domain.pointhistory.entity.PointHistoryDetail;
+import shop.bookbom.shop.domain.pointrate.entity.PointRate;
+import shop.bookbom.shop.domain.rank.entity.Rank;
+import shop.bookbom.shop.domain.role.entity.Role;
+
+@DataJpaTest
+@Import(TestQuerydslConfig.class)
+class PointHistoryRepositoryTest {
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    PointHistoryRepository pointHistoryRepository;
+
+    @Test
+    @DisplayName("회원 포인트 적립 내역 조회")
+    void findPointHistory() {
+        //given
+        Role role = em.persist(getRole());
+        PointRate pointRate = em.persist(getPointRate());
+        Rank rank = em.persist(getRank(pointRate));
+        Member member = em.persist(getMember("email@test.com", role, rank));
+        for (int i = 0; i < 5; i++) {
+            em.persist(getPointHistory(member, ChangeReason.EARN));
+            em.persist(getPointHistory(member, ChangeReason.USE));
+        }
+        //when
+        PageRequest pageRequest = PageRequest.of(0, 3);
+        Page<PointHistoryResponse> result =
+                pointHistoryRepository.getPointHistory(member, pageRequest, ChangeReason.EARN);
+
+        //then
+        PointHistoryResponse response = result.getContent().get(0);
+        assertThat(result.getSize()).isEqualTo(3);
+        assertThat(result.getTotalElements()).isEqualTo(5);
+        assertThat(response.getReason()).isEqualTo(ChangeReason.EARN.name());
+        assertThat(response.getChangePoint()).isEqualTo(100);
+        assertThat(response.getDetail()).isEqualTo(PointHistoryDetail.ORDER_EARN.name());
+    }
+
+    @Test
+    @DisplayName("필터링 조건 없을 때 회원 포인트 내역 조회")
+    void findPointHistoryNotFiltered() {
+        //given
+        Role role = em.persist(getRole());
+        PointRate pointRate = em.persist(getPointRate());
+        Rank rank = em.persist(getRank(pointRate));
+        Member member = em.persist(getMember("email@test.com", role, rank));
+        for (int i = 0; i < 5; i++) {
+            em.persist(getPointHistory(member, ChangeReason.EARN));
+            em.persist(getPointHistory(member, ChangeReason.USE));
+        }
+        //when
+        PageRequest pageRequest = PageRequest.of(0, 3);
+        Page<PointHistoryResponse> result =
+                pointHistoryRepository.getPointHistory(member, pageRequest, null);
+
+        //then
+        PointHistoryResponse response = result.getContent().get(0);
+        assertThat(result.getSize()).isEqualTo(3);
+        assertThat(result.getTotalElements()).isEqualTo(10);
+        assertThat(response.getReason()).isEqualTo(ChangeReason.EARN.name());
+        assertThat(response.getChangePoint()).isEqualTo(100);
+        assertThat(response.getDetail()).isEqualTo(PointHistoryDetail.ORDER_EARN.name());
+    }
+}

--- a/src/test/java/shop/bookbom/shop/domain/pointhistory/service/PointHistoryServiceTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/pointhistory/service/PointHistoryServiceTest.java
@@ -45,7 +45,7 @@ class PointHistoryServiceTest {
         //given
         when(memberRepository.findById(any())).thenReturn(
                 Optional.of(getMember("email@test.com", getRole(), getRank(getPointRate()))));
-        PointHistoryResponse response = getPointHistoryResponse(ChangeReason.EARN);
+        PointHistoryResponse response = getPointHistoryResponse(ChangeReason.USE);
         PageRequest pageRequest = PageRequest.of(0, 5);
         when(pointHistoryRepository.getPointHistory(any(), any(), any()))
                 .thenReturn(new PageImpl<>(List.of(response), pageRequest, 1));

--- a/src/test/java/shop/bookbom/shop/domain/pointhistory/service/PointHistoryServiceTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/pointhistory/service/PointHistoryServiceTest.java
@@ -45,7 +45,7 @@ class PointHistoryServiceTest {
         //given
         when(memberRepository.findById(any())).thenReturn(
                 Optional.of(getMember("email@test.com", getRole(), getRank(getPointRate()))));
-        PointHistoryResponse response = getPointHistoryResponse();
+        PointHistoryResponse response = getPointHistoryResponse(ChangeReason.EARN);
         PageRequest pageRequest = PageRequest.of(0, 5);
         when(pointHistoryRepository.getPointHistory(any(), any(), any()))
                 .thenReturn(new PageImpl<>(List.of(response), pageRequest, 1));

--- a/src/test/java/shop/bookbom/shop/domain/pointhistory/service/PointHistoryServiceTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/pointhistory/service/PointHistoryServiceTest.java
@@ -1,0 +1,62 @@
+package shop.bookbom.shop.domain.pointhistory.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static shop.bookbom.shop.common.TestUtils.getMember;
+import static shop.bookbom.shop.common.TestUtils.getPointHistoryResponse;
+import static shop.bookbom.shop.common.TestUtils.getPointRate;
+import static shop.bookbom.shop.common.TestUtils.getRank;
+import static shop.bookbom.shop.common.TestUtils.getRole;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import shop.bookbom.shop.domain.member.repository.MemberRepository;
+import shop.bookbom.shop.domain.pointhistory.dto.response.PointHistoryResponse;
+import shop.bookbom.shop.domain.pointhistory.entity.ChangeReason;
+import shop.bookbom.shop.domain.pointhistory.entity.PointHistoryDetail;
+import shop.bookbom.shop.domain.pointhistory.repository.PointHistoryRepository;
+import shop.bookbom.shop.domain.pointhistory.service.impl.PointHistoryServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+class PointHistoryServiceTest {
+
+    @Mock
+    PointHistoryRepository pointHistoryRepository;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @InjectMocks
+    PointHistoryServiceImpl pointHistoryService;
+
+    @Test
+    @DisplayName("포인트 내역 조회")
+    void findPointHistory() {
+        //given
+        when(memberRepository.findById(any())).thenReturn(
+                Optional.of(getMember("email@test.com", getRole(), getRank(getPointRate()))));
+        PointHistoryResponse response = getPointHistoryResponse();
+        PageRequest pageRequest = PageRequest.of(0, 5);
+        when(pointHistoryRepository.getPointHistory(any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(response), pageRequest, 1));
+        //when
+        Page<PointHistoryResponse> pointHistory = pointHistoryService.findPointHistory(1L, pageRequest, null);
+        //then
+        List<PointHistoryResponse> content = pointHistory.getContent();
+        PointHistoryResponse result = content.get(0);
+        assertThat(content).hasSize(1);
+        assertThat(result.getReason()).isEqualTo(ChangeReason.USE.name());
+        assertThat(result.getChangePoint()).isEqualTo(1000);
+        assertThat(result.getDetail()).isEqualTo(PointHistoryDetail.ORDER_EARN.name());
+    }
+}


### PR DESCRIPTION
# 설명
- 회원 포인트 적립/사용 내역 API를 구현하였습니다.

# 작업내용
- 페이징 기능을 제공합니다.
- 사용, 적립 내역을 필터링해서 확인할 수 있습니다.
 
![image](https://github.com/nhnacademy-be5-bom/bookbom-shop/assets/95916780/43fedfcd-94c0-4e22-b1c5-be9a5fa51d1a)
