### PR TITLE
[fix] API 경로 매핑 수정

### DIFF
--- a/src/main/java/shop/bookbom/shop/domain/member/controller/MemberController.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/controller/MemberController.java
@@ -15,7 +15,7 @@ import shop.bookbom.shop.domain.member.service.MemberService;
 public class MemberController {
     private final MemberService memberService;
 
-    @GetMapping("/member/my-page")
+    @GetMapping("/users/my-page")
     public CommonResponse<MemberInfoResponse> myPage(@RequestParam("userId") Long id) {
         return CommonResponse.successWithData(memberService.getMemberInfo(id));
     }

--- a/src/main/java/shop/bookbom/shop/domain/member/repository/impl/MemberRepositoryImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/repository/impl/MemberRepositoryImpl.java
@@ -30,7 +30,10 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .join(member.rank, rank).fetchJoin()
                 .leftJoin(member.orders, order).fetchJoin()
                 .leftJoin(order.status, orderStatus).fetchJoin()
-                .where(member.id.eq(id))
+                .where(
+                        member.id.eq(id),
+                        order.status.name.ne("결제전")
+                )
                 .fetchOne();
 
         if (memberResult == null) {

--- a/src/main/java/shop/bookbom/shop/domain/pointhistory/controller/PointHistoryController.java
+++ b/src/main/java/shop/bookbom/shop/domain/pointhistory/controller/PointHistoryController.java
@@ -35,7 +35,7 @@ public class PointHistoryController {
                 .orElseThrow(InvalidChangeReasonException::new);
     }
 
-    @GetMapping("/member/point-history")
+    @GetMapping("/users/point-history")
     public CommonResponse<Page<PointHistoryResponse>> getPointHistory(
             @RequestParam Long userId,
             Pageable pageable,

--- a/src/main/java/shop/bookbom/shop/domain/users/repository/impl/UserRepositoryImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/users/repository/impl/UserRepositoryImpl.java
@@ -30,7 +30,8 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                 .where(
                         order.user.eq(user),
                         orderDateMin(condition.getOrderDateMin()),
-                        orderDateMax(condition.getOrderDateMax())
+                        orderDateMax(condition.getOrderDateMax()),
+                        order.status.name.ne("결제전")
                 )
                 .orderBy(order.orderDate.desc())
                 .offset(pageable.getOffset())


### PR DESCRIPTION
# 설명
- front와 API 서버 간의 URL 매핑 잘못되어있는 부분을 수정했습니다.
- 마이페이지에서 최근 주문 목록을 조회할 때 결제전 주문은 가져오지 않도록 수정했습니다.