### PR TITLE
[feat] 컨트롤러 메서드에서 회원 ID 가져오는 작업 공통화 처리

### DIFF
--- a/src/main/java/shop/bookbom/shop/argumentresolver/LoginArgumentResolver.java
+++ b/src/main/java/shop/bookbom/shop/argumentresolver/LoginArgumentResolver.java
@@ -15,7 +15,7 @@ import shop.bookbom.shop.security.jwt.JwtConfig;
 
 @Slf4j
 @RequiredArgsConstructor
-public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
     private final JwtConfig jwtConfig;
 
     @Override
@@ -32,7 +32,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
             MethodParameter parameter,
             ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
             WebDataBinderFactory binderFactory
-    ) throws Exception {
+    ) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String token = jwtConfig.resolveToken(request);
         UserIdRole userIdRole = jwtConfig.getUserIdRole(token);

--- a/src/main/java/shop/bookbom/shop/config/SecurityConfig.java
+++ b/src/main/java/shop/bookbom/shop/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package shop.bookbom.shop.config;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,16 +15,13 @@ import shop.bookbom.shop.security.jwt.JwtConfig;
 @Slf4j
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
-
-    @Bean
-    public JwtConfig jwtConfig() {
-        return new JwtConfig();
-    }
+    private final JwtConfig jwtConfig;
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(jwtConfig());
+        return new JwtAuthenticationFilter(jwtConfig);
     }
 
     @Bean

--- a/src/main/java/shop/bookbom/shop/config/WebConfig.java
+++ b/src/main/java/shop/bookbom/shop/config/WebConfig.java
@@ -2,19 +2,23 @@ package shop.bookbom.shop.config;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import shop.bookbom.shop.argumentresolver.LoginMemberArgumentResolver;
+import shop.bookbom.shop.argumentresolver.LoginArgumentResolver;
 import shop.bookbom.shop.security.jwt.JwtConfig;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
-    private final JwtConfig jwtConfig;
+    @Bean
+    public JwtConfig jwtConfig() {
+        return new JwtConfig();
+    }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new LoginMemberArgumentResolver(jwtConfig));
+        resolvers.add(new LoginArgumentResolver(jwtConfig()));
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/cart/controller/CartController.java
+++ b/src/main/java/shop/bookbom/shop/domain/cart/controller/CartController.java
@@ -38,7 +38,7 @@ public class CartController {
      * @param userDto  로그인한 회원 정보
      * @param requests 장바구니 추가할 상품 ID와 수량 리스트
      */
-    @PostMapping("/carts/{id}")
+    @PostMapping("/carts")
     public CommonListResponse<Long> addToCart(
             @Login UserDto userDto,
             @RequestBody List<CartAddRequest> requests
@@ -55,7 +55,7 @@ public class CartController {
      * @param userDto 로그인한 회원 정보
      * @return 장바구니 ID, 상품 ID와 수량 리스트
      */
-    @GetMapping("/carts/{id}")
+    @GetMapping("/carts")
     public CommonResponse<CartInfoResponse> getCart(@Login UserDto userDto) {
         return successWithData(cartService.getCartInfo(userDto.getId()));
     }

--- a/src/main/java/shop/bookbom/shop/domain/member/repository/MemberRepository.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/repository/MemberRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import shop.bookbom.shop.domain.member.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/shop/bookbom/shop/domain/member/service/MemberService.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/service/MemberService.java
@@ -18,4 +18,11 @@ public interface MemberService {
      * @param signUpRequest 회원가입 요청 정보
      */
     void save(SignUpRequest signUpRequest);
+
+    /**
+     * 회원의 닉네임을 중복 체크하는 메서드입니다.
+     * @param nickname
+     * @return
+     */
+    boolean checkNicknameCanUse(String nickname);
 }

--- a/src/main/java/shop/bookbom/shop/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/service/impl/MemberServiceImpl.java
@@ -84,4 +84,10 @@ public class MemberServiceImpl implements MemberService {
                 .build();
         addressRepository.save(address);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean checkNicknameCanUse(String nickname) {
+        return !memberRepository.existsByNickname(nickname);
+    }
 }

--- a/src/main/java/shop/bookbom/shop/domain/users/controller/OpenUserController.java
+++ b/src/main/java/shop/bookbom/shop/domain/users/controller/OpenUserController.java
@@ -7,7 +7,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import shop.bookbom.shop.common.CommonResponse;
 import shop.bookbom.shop.common.exception.InvalidParameterException;
-import shop.bookbom.shop.domain.users.dto.response.EmailCheckResponse;
+import shop.bookbom.shop.domain.member.service.MemberService;
+import shop.bookbom.shop.domain.users.dto.response.SignupCheckResponse;
 import shop.bookbom.shop.domain.users.service.UserService;
 
 @RestController
@@ -15,15 +16,27 @@ import shop.bookbom.shop.domain.users.service.UserService;
 @RequestMapping("/shop/open")
 public class OpenUserController {
     private final UserService userService;
+    private final MemberService memberService;
 
     @GetMapping("/users/check-email")
-    public CommonResponse<EmailCheckResponse> checkEmail(
+    public CommonResponse<SignupCheckResponse> checkEmail(
             @RequestParam(value = "email", required = false) String email
     ) {
         if (email == null || email.isEmpty()) {
             throw new InvalidParameterException("이메일을 입력해주세요.");
         }
         boolean canUse = userService.checkEmailCanUse(email);
-        return CommonResponse.successWithData(new EmailCheckResponse(canUse));
+        return CommonResponse.successWithData(new SignupCheckResponse(canUse));
+    }
+
+    @GetMapping("/users/check-nickname")
+    public CommonResponse<SignupCheckResponse> checkNickname(
+            @RequestParam(value = "nickname", required = false) String nickname
+    ) {
+        if (nickname == null || nickname.isEmpty()) {
+            throw new InvalidParameterException("닉네임을 입력해주세요.");
+        }
+        boolean canUse = memberService.checkNicknameCanUse(nickname);
+        return CommonResponse.successWithData(new SignupCheckResponse(canUse));
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/users/dto/response/SignupCheckResponse.java
+++ b/src/main/java/shop/bookbom/shop/domain/users/dto/response/SignupCheckResponse.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class EmailCheckResponse {
+public class SignupCheckResponse {
     private boolean canUse;
 }

--- a/src/test/java/shop/bookbom/shop/domain/booktag/controller/BookTagControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/booktag/controller/BookTagControllerTest.java
@@ -49,7 +49,7 @@ class BookTagControllerTest {
         when(bookTagService.getBookTagInformation(bookId)).thenReturn(Collections.singletonList(response));
 
         // When & Then
-        mockMvc.perform(get("/shop/book/tag/{id}", bookId))
+        mockMvc.perform(get("/shop/books/tag/{id}", bookId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.header.resultCode").value(200))
                 .andExpect(jsonPath("$.header.resultMessage").value("SUCCESS"))
@@ -67,7 +67,7 @@ class BookTagControllerTest {
         long bookId = 2L;
 
         // When
-        mockMvc.perform(post("/shop/book/tag")
+        mockMvc.perform(post("/shop/books/tag")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"tagId\":1,\"bookId\":2}"))
                 .andExpect(status().isOk());
@@ -83,7 +83,7 @@ class BookTagControllerTest {
         doNothing().when(bookTagService).deleteBookTagService(bookTagId);
 
         // When & Then
-        mockMvc.perform(delete("/shop/book/tag/{id}", bookTagId))
+        mockMvc.perform(delete("/shop/books/tag/{id}", bookTagId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.header.resultCode").value(200))
                 .andExpect(jsonPath("$.header.resultMessage").value("SUCCESS"))
@@ -96,7 +96,7 @@ class BookTagControllerTest {
         // Given
         String requestBody = "{\"tagId\":0,\"bookId\":0}"; // 유효하지 않은 값
         // When & Then
-        mockMvc.perform(post("/shop/book/tag")
+        mockMvc.perform(post("/shop/books/tag")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(jsonPath("$.header.successful").value(false))

--- a/src/test/java/shop/bookbom/shop/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/member/controller/MemberControllerTest.java
@@ -1,5 +1,6 @@
 package shop.bookbom.shop.domain.member.controller;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -19,16 +20,23 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import shop.bookbom.shop.argumentresolver.LoginArgumentResolver;
+import shop.bookbom.shop.config.WebConfig;
 import shop.bookbom.shop.domain.member.service.MemberService;
 import shop.bookbom.shop.domain.rank.entity.Rank;
+import shop.bookbom.shop.domain.users.dto.UserDto;
 
 @AutoConfigureMockMvc(addFilters = false)
 @ExtendWith(MockitoExtension.class)
-@WebMvcTest(MemberController.class)
+@WebMvcTest(
+        value = MemberController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class))
 class MemberControllerTest {
     @Autowired
     MockMvc mockMvc;
@@ -36,16 +44,19 @@ class MemberControllerTest {
     @MockBean
     MemberService memberService;
 
+    @MockBean
+    LoginArgumentResolver resolver;
+
     @Test
     @DisplayName("마이 페이지")
     void myPage() throws Exception {
         //given
         Rank rank = getRank(getPointRate());
-        when(memberService.getMemberInfo(1L)).thenReturn(
+        when(memberService.getMemberInfo(any())).thenReturn(
                 getMemberInfoResponse(rank, getMember("test@email.com", getRole(), rank)));
+        when(resolver.resolveArgument(any(), any(), any(), any())).thenReturn(new UserDto(1L));
         //when
-        ResultActions perform = mockMvc.perform(get("/shop/users/my-page")
-                .param("userId", "1"));
+        ResultActions perform = mockMvc.perform(get("/shop/users/my-page"));
 
         //then
         perform

--- a/src/test/java/shop/bookbom/shop/domain/pointhistory/controller/PointHistoryControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/pointhistory/controller/PointHistoryControllerTest.java
@@ -18,6 +18,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -25,18 +27,24 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import shop.bookbom.shop.argumentresolver.LoginArgumentResolver;
+import shop.bookbom.shop.config.WebConfig;
 import shop.bookbom.shop.domain.pointhistory.dto.response.PointHistoryResponse;
 import shop.bookbom.shop.domain.pointhistory.entity.ChangeReason;
 import shop.bookbom.shop.domain.pointhistory.service.PointHistoryService;
+import shop.bookbom.shop.domain.users.dto.UserDto;
 
 @AutoConfigureMockMvc(addFilters = false)
 @ExtendWith(MockitoExtension.class)
-@WebMvcTest(PointHistoryController.class)
+@WebMvcTest(
+        value = PointHistoryController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class))
 class PointHistoryControllerTest {
 
     @Autowired
     MockMvc mockMvc;
-
+    @MockBean
+    LoginArgumentResolver resolver;
     @MockBean
     PointHistoryService pointHistoryService;
 
@@ -47,8 +55,8 @@ class PointHistoryControllerTest {
         PageRequest pageRequest = PageRequest.of(0, 5);
         PageImpl<PointHistoryResponse> page = new PageImpl<>(List.of(pointHistoryResponse), pageRequest, 1);
         when(pointHistoryService.findPointHistory(any(), any(), any())).thenReturn(page);
-        ResultActions perform = mockMvc.perform(get("/shop/users/point-history")
-                .param("userId", "1"));
+        when(resolver.resolveArgument(any(), any(), any(), any())).thenReturn(new UserDto(1L));
+        ResultActions perform = mockMvc.perform(get("/shop/users/point-history"));
         perform
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -68,8 +76,8 @@ class PointHistoryControllerTest {
         PageImpl<PointHistoryResponse> page = new PageImpl<>(List.of(pointHistoryResponse), pageRequest, 1);
         when(pointHistoryService.findPointHistory(any(), any(), eq(ChangeReason.EARN))).thenReturn(page);
         when(pointHistoryService.findPointHistory(any(), any(), eq(ChangeReason.USE))).thenReturn(Page.empty());
+        when(resolver.resolveArgument(any(), any(), any(), any())).thenReturn(new UserDto(1L));
         ResultActions perform = mockMvc.perform(get("/shop/users/point-history")
-                .param("userId", "1")
                 .param("reason", "USE"));
         perform
                 .andExpect(status().isOk())
@@ -87,8 +95,8 @@ class PointHistoryControllerTest {
         PageRequest pageRequest = PageRequest.of(0, 5);
         PageImpl<PointHistoryResponse> page = new PageImpl<>(List.of(pointHistoryResponse), pageRequest, 1);
         when(pointHistoryService.findPointHistory(any(), any(), any())).thenReturn(page);
+        when(resolver.resolveArgument(any(), any(), any(), any())).thenReturn(new UserDto(1L));
         ResultActions perform = mockMvc.perform(get("/shop/users/point-history")
-                .param("userId", "1")
                 .param("reason", "TESTTT"));
         perform
                 .andExpect(status().isOk())

--- a/src/test/java/shop/bookbom/shop/domain/user/controller/OpenUserControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/user/controller/OpenUserControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
+import shop.bookbom.shop.domain.member.service.MemberService;
 import shop.bookbom.shop.domain.users.controller.OpenUserController;
 import shop.bookbom.shop.domain.users.service.UserService;
 
@@ -31,6 +32,9 @@ class OpenUserControllerTest {
 
     @MockBean
     UserService userService;
+
+    @MockBean
+    MemberService memberService;
 
     @Test
     @DisplayName("이메일 중복 체크")

--- a/src/test/java/shop/bookbom/shop/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/user/controller/UserControllerTest.java
@@ -27,14 +27,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import shop.bookbom.shop.argumentresolver.LoginArgumentResolver;
+import shop.bookbom.shop.config.WebConfig;
 import shop.bookbom.shop.domain.order.dto.response.OrderInfoResponse;
 import shop.bookbom.shop.domain.users.controller.UserController;
+import shop.bookbom.shop.domain.users.dto.UserDto;
 import shop.bookbom.shop.domain.users.dto.request.ResetPasswordRequestDto;
 import shop.bookbom.shop.domain.users.dto.request.UserRequestDto;
 import shop.bookbom.shop.domain.users.entity.User;
@@ -45,7 +50,9 @@ import shop.bookbom.shop.domain.users.service.UserService;
 
 @AutoConfigureMockMvc(addFilters = false)
 @ExtendWith(MockitoExtension.class)
-@WebMvcTest(UserController.class)
+@WebMvcTest(
+        value = UserController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class))
 class UserControllerTest {
 
     @Autowired
@@ -53,6 +60,9 @@ class UserControllerTest {
 
     @Autowired
     ObjectMapper objectMapper;
+
+    @MockBean
+    LoginArgumentResolver resolver;
 
     @MockBean
     UserService userService;
@@ -187,6 +197,7 @@ class UserControllerTest {
         PageRequest pageRequest = PageRequest.of(0, 10);
         when(userService.getOrderInfos(any(), any(), any()))
                 .thenReturn(new PageImpl<>(content, pageRequest, content.size()));
+        when(resolver.resolveArgument(any(), any(), any(), any())).thenReturn(new UserDto(1L));
         //when
         ResultActions perform = mockMvc.perform(get("/shop/users/orders")
                 .param("userId", "1"));
@@ -209,6 +220,7 @@ class UserControllerTest {
         PageRequest pageRequest = PageRequest.of(0, 10);
         when(userService.getOrderInfos(any(), any(), any()))
                 .thenReturn(new PageImpl<>(content, pageRequest, content.size()));
+        when(resolver.resolveArgument(any(), any(), any(), any())).thenReturn(new UserDto(1L));
         //when
         ResultActions perform = mockMvc.perform(get("/shop/users/orders")
                 .param("userId", "1")


### PR DESCRIPTION
# 설명
- 컨트롤러 메서드에서 userId를 통한 조회가 필요할 때, 커스텀 어노테이션을 이용해서 공통화된 작업을 통해 가져올 수 있도록 처리하였습니다.

# 작업내용

### 컨트롤러에서 회원 ID를 받아오는 방법
회원의 id가 필요하다면 Controller 메서드에서 파라미터에 `@Login UserDto userDto` 를 넣으시면 됩니다.
ex)
```
    @GetMapping("/users/my-page")
    public CommonResponse<MemberInfoResponse> myPage(@Login UserDto userDto) {
        return CommonResponse.successWithData(memberService.getMemberInfo(userDto.getId()));
    }
```
UserDto 안에는 현재 id 필드가 있고, `userDto.getId()`를 통해 현재 로그인되어있는 회원의 ID를 가져올 수 있습니다.
이는 ArgumentResolver와 커스텀 어노테이션을 이용해서 구현하였고, 
ArgumentResolver에서는 request 헤더에서 Authorization이 있다면 받아온 토큰을 decode하여 회원의 ID를 가져옵니다.
없다면 null을 반환합니다.

### `@Login` 어노테이션이 달린 컨트롤러의 테스트 코드 작성 방법
`@Login` 어노테이션이 달린 컨트롤러 메서드의 테스트 코드를 작성할 때 해야 할 설정은 다음과 같습니다.
기존에 설정된 `LoginArgumentResolver`를 Mocking해서 사용하기 위해 작업합니다.
1. `LoginArgumentResolver`가 설정되어있는 기존 WebConfig를 exclude합니다.
```
@WebMvcTest(
        value = Controller.class,
        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class))
```
2. `LoginArgumentResolver`를 `@MockBean`으로 선언합니다.
```
@MockBean
LoginArgumentResolver resolver;
```
3. 테스트 메서드에서 resolver를 Mockito를 이용해 stubbing해줍니다.
```
when(resolver.resolveArgument(any(), any(), any(), any())).thenReturn(new UserDto(1L));
```