### PR TITLE
[feat] 회원 등급 조회 구현

### DIFF
--- a/src/main/java/shop/bookbom/shop/domain/member/controller/MemberController.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 import shop.bookbom.shop.annotation.Login;
 import shop.bookbom.shop.common.CommonResponse;
 import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
+import shop.bookbom.shop.domain.member.dto.response.MemberRankResponse;
 import shop.bookbom.shop.domain.member.service.MemberService;
 import shop.bookbom.shop.domain.users.dto.UserDto;
 
@@ -19,5 +20,10 @@ public class MemberController {
     @GetMapping("/users/my-page")
     public CommonResponse<MemberInfoResponse> myPage(@Login UserDto userDto) {
         return CommonResponse.successWithData(memberService.getMemberInfo(userDto.getId()));
+    }
+
+    @GetMapping("/users/my-rank")
+    public CommonResponse<MemberRankResponse> userRank(@Login UserDto userDto) {
+        return CommonResponse.successWithData(memberService.getUserRank(userDto.getId()));
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/member/dto/response/MemberRankResponse.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/dto/response/MemberRankResponse.java
@@ -1,0 +1,18 @@
+package shop.bookbom.shop.domain.member.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberRankResponse {
+    private String nickname;
+    private String userrank;
+
+    @Builder
+    @QueryProjection
+    public MemberRankResponse(String nickname, String userrank) {
+        this.nickname = nickname;
+        this.userrank = userrank;
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/member/dto/response/MemberRankResponse.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/dto/response/MemberRankResponse.java
@@ -4,17 +4,17 @@ import com.querydsl.core.annotations.QueryProjection;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+import shop.bookbom.shop.domain.rank.dto.response.RankResponse;
 import shop.bookbom.shop.domain.rank.entity.Rank;
 
 @Getter
 public class MemberRankResponse {
     private String nickname;
     private String userrank;
-    private List<Rank> ranks;
+    private List<RankResponse> ranks;
 
     @Builder
-    @QueryProjection
-    public MemberRankResponse(String nickname, String userrank, List<Rank> ranks) {
+    public MemberRankResponse(String nickname, String userrank, List<RankResponse> ranks) {
         this.nickname = nickname;
         this.userrank = userrank;
         this.ranks = ranks;

--- a/src/main/java/shop/bookbom/shop/domain/member/dto/response/MemberRankResponse.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/dto/response/MemberRankResponse.java
@@ -1,18 +1,22 @@
 package shop.bookbom.shop.domain.member.dto.response;
 
 import com.querydsl.core.annotations.QueryProjection;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+import shop.bookbom.shop.domain.rank.entity.Rank;
 
 @Getter
 public class MemberRankResponse {
     private String nickname;
     private String userrank;
+    private List<Rank> ranks;
 
     @Builder
     @QueryProjection
-    public MemberRankResponse(String nickname, String userrank) {
+    public MemberRankResponse(String nickname, String userrank, List<Rank> ranks) {
         this.nickname = nickname;
         this.userrank = userrank;
+        this.ranks = ranks;
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/repository/MemberRepositoryCustom.java
@@ -1,7 +1,9 @@
 package shop.bookbom.shop.domain.member.repository;
 
 import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
+import shop.bookbom.shop.domain.member.entity.Member;
 
 public interface MemberRepositoryCustom {
     MemberInfoResponse findMemberInfo(Long id);
+    Member findMemberByIdFetchRank(Long id);
 }

--- a/src/main/java/shop/bookbom/shop/domain/member/repository/impl/MemberRepositoryImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/repository/impl/MemberRepositoryImpl.java
@@ -71,4 +71,14 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .wishCount((wishCount != null) ? wishCount : 0L)
                 .build();
     }
+
+    @Override
+    public Member findMemberByIdFetchRank(Long id){
+        return queryFactory
+                .select(member)
+                .from(member)
+                .leftJoin(member.rank, rank).fetchJoin()
+                .where(member.id.eq(id))
+                .fetchOne();
+    }
 }

--- a/src/main/java/shop/bookbom/shop/domain/member/service/MemberService.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package shop.bookbom.shop.domain.member.service;
 
 import shop.bookbom.shop.domain.member.dto.request.SignUpRequest;
 import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
+import shop.bookbom.shop.domain.member.dto.response.MemberRankResponse;
 
 public interface MemberService {
     /**
@@ -25,4 +26,9 @@ public interface MemberService {
      * @return
      */
     boolean checkNicknameCanUse(String nickname);
+
+    /**
+     * 회원 등급 조회페이지에 출력할 정보를 가져오는 메서드입니다.
+     */
+    MemberRankResponse getUserRank(Long id);
 }

--- a/src/main/java/shop/bookbom/shop/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/service/impl/MemberServiceImpl.java
@@ -1,6 +1,7 @@
 package shop.bookbom.shop.domain.member.service.impl;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -98,10 +99,11 @@ public class MemberServiceImpl implements MemberService {
     public MemberRankResponse getUserRank(Long id) {
         Member member = memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
         Rank userRank = rankRepository.findById(member.getRank().getId()).orElseThrow(RankNotFoundException::new);
-
+        List<Rank> ranks = rankRepository.getAllRankFetchPointRate();
         return MemberRankResponse.builder()
                 .nickname(member.getNickname())
                 .userrank(userRank.getName())
+                .ranks(ranks)
                 .build();
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/service/impl/MemberServiceImpl.java
@@ -125,6 +125,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public MemberRankResponse getUserRank(Long id) {
         Member member = memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
         Rank userRank = rankRepository.findById(member.getRank().getId()).orElseThrow(RankNotFoundException::new);

--- a/src/main/java/shop/bookbom/shop/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/service/impl/MemberServiceImpl.java
@@ -8,8 +8,10 @@ import shop.bookbom.shop.domain.address.entity.Address;
 import shop.bookbom.shop.domain.address.repository.AddressRepository;
 import shop.bookbom.shop.domain.member.dto.request.SignUpRequest;
 import shop.bookbom.shop.domain.member.dto.response.MemberInfoResponse;
+import shop.bookbom.shop.domain.member.dto.response.MemberRankResponse;
 import shop.bookbom.shop.domain.member.entity.Member;
 import shop.bookbom.shop.domain.member.entity.MemberStatus;
+import shop.bookbom.shop.domain.member.exception.MemberNotFoundException;
 import shop.bookbom.shop.domain.member.repository.MemberRepository;
 import shop.bookbom.shop.domain.member.service.MemberService;
 import shop.bookbom.shop.domain.pointhistory.entity.ChangeReason;
@@ -20,6 +22,7 @@ import shop.bookbom.shop.domain.pointrate.entity.PointRate;
 import shop.bookbom.shop.domain.pointrate.exception.PointRateNotFoundException;
 import shop.bookbom.shop.domain.pointrate.repository.PointRateRepository;
 import shop.bookbom.shop.domain.rank.entity.Rank;
+import shop.bookbom.shop.domain.rank.exception.RankNotFoundException;
 import shop.bookbom.shop.domain.rank.repository.RankRepository;
 import shop.bookbom.shop.domain.role.entity.Role;
 import shop.bookbom.shop.domain.role.repository.RoleRepository;
@@ -89,5 +92,16 @@ public class MemberServiceImpl implements MemberService {
     @Transactional(readOnly = true)
     public boolean checkNicknameCanUse(String nickname) {
         return !memberRepository.existsByNickname(nickname);
+    }
+
+    @Override
+    public MemberRankResponse getUserRank(Long id) {
+        Member member = memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
+        Rank userRank = rankRepository.findById(member.getRank().getId()).orElseThrow(RankNotFoundException::new);
+
+        return MemberRankResponse.builder()
+                .nickname(member.getNickname())
+                .userrank(userRank.getName())
+                .build();
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/member/service/impl/MemberServiceImpl.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.bookbom.shop.domain.address.entity.Address;
@@ -30,12 +31,14 @@ import shop.bookbom.shop.domain.pointhistory.repository.PointHistoryRepository;
 import shop.bookbom.shop.domain.pointrate.entity.PointRate;
 import shop.bookbom.shop.domain.pointrate.exception.PointRateNotFoundException;
 import shop.bookbom.shop.domain.pointrate.repository.PointRateRepository;
+import shop.bookbom.shop.domain.rank.dto.response.RankResponse;
 import shop.bookbom.shop.domain.rank.entity.Rank;
 import shop.bookbom.shop.domain.rank.exception.RankNotFoundException;
 import shop.bookbom.shop.domain.rank.repository.RankRepository;
 import shop.bookbom.shop.domain.role.entity.Role;
 import shop.bookbom.shop.domain.role.repository.RoleRepository;
 import shop.bookbom.shop.domain.users.exception.RoleNotFoundException;
+import shop.bookbom.shop.domain.users.exception.UserNotFoundException;
 
 @Service
 @RequiredArgsConstructor
@@ -136,12 +139,14 @@ public class MemberServiceImpl implements MemberService {
     @Override
     @Transactional(readOnly = true)
     public MemberRankResponse getUserRank(Long id) {
-        Member member = memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
-        Rank userRank = rankRepository.findById(member.getRank().getId()).orElseThrow(RankNotFoundException::new);
-        List<Rank> ranks = rankRepository.getAllRankFetchPointRate();
+        Member member = memberRepository.findMemberByIdFetchRank(id);
+        if(member == null){
+            throw new UserNotFoundException();
+        }
+        List<RankResponse> ranks = rankRepository.getAllRankFetchPointRate();
         return MemberRankResponse.builder()
                 .nickname(member.getNickname())
-                .userrank(userRank.getName())
+                .userrank(member.getRank().getName())
                 .ranks(ranks)
                 .build();
     }

--- a/src/main/java/shop/bookbom/shop/domain/rank/dto/response/RankResponse.java
+++ b/src/main/java/shop/bookbom/shop/domain/rank/dto/response/RankResponse.java
@@ -1,0 +1,21 @@
+package shop.bookbom.shop.domain.rank.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import shop.bookbom.shop.domain.pointrate.entity.EarnPointType;
+
+@Getter
+@NoArgsConstructor
+public class RankResponse {
+    private String name;
+    private int earnPoint;
+    private EarnPointType earnType;
+
+    @Builder
+    public RankResponse(String name, int earnPoint, EarnPointType earnType) {
+        this.name = name;
+        this.earnPoint = earnPoint;
+        this.earnType = earnType;
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/rank/repository/RankRepositoryCustom.java
+++ b/src/main/java/shop/bookbom/shop/domain/rank/repository/RankRepositoryCustom.java
@@ -1,6 +1,8 @@
 package shop.bookbom.shop.domain.rank.repository;
 
+import com.querydsl.core.Tuple;
 import java.util.List;
+import shop.bookbom.shop.domain.rank.dto.response.RankResponse;
 import shop.bookbom.shop.domain.rank.entity.Rank;
 
 public interface RankRepositoryCustom {
@@ -17,5 +19,5 @@ public interface RankRepositoryCustom {
      *
      * @return Rank 엔티티 리스트
      */
-    List<Rank> getAllRankFetchPointRate();
+    List<RankResponse> getAllRankFetchPointRate();
 }

--- a/src/main/java/shop/bookbom/shop/domain/rank/repository/RankRepositoryCustom.java
+++ b/src/main/java/shop/bookbom/shop/domain/rank/repository/RankRepositoryCustom.java
@@ -1,5 +1,6 @@
 package shop.bookbom.shop.domain.rank.repository;
 
+import java.util.List;
 import shop.bookbom.shop.domain.rank.entity.Rank;
 
 public interface RankRepositoryCustom {
@@ -10,4 +11,11 @@ public interface RankRepositoryCustom {
      * @return Rank 엔티티
      */
     Rank getRankByNameFetchPointRate(String name);
+
+    /**
+     * 모든 Rank를 조회하고 PointRate를 fetch join하여 반환하는 메서드입니다.
+     *
+     * @return Rank 엔티티 리스트
+     */
+    List<Rank> getAllRankFetchPointRate();
 }

--- a/src/main/java/shop/bookbom/shop/domain/rank/repository/impl/RankRepositoryImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/rank/repository/impl/RankRepositoryImpl.java
@@ -3,9 +3,13 @@ package shop.bookbom.shop.domain.rank.repository.impl;
 import static shop.bookbom.shop.domain.pointrate.entity.QPointRate.pointRate;
 import static shop.bookbom.shop.domain.rank.entity.QRank.rank;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import shop.bookbom.shop.domain.pointrate.entity.ApplyPointType;
+import shop.bookbom.shop.domain.rank.dto.response.RankResponse;
 import shop.bookbom.shop.domain.rank.entity.Rank;
 import shop.bookbom.shop.domain.rank.exception.RankNotFoundException;
 import shop.bookbom.shop.domain.rank.repository.RankRepositoryCustom;
@@ -29,11 +33,24 @@ public class RankRepositoryImpl implements RankRepositoryCustom {
     }
 
     @Override
-    public List<Rank> getAllRankFetchPointRate(){
-        return queryFactory
-                .select(rank)
+    public List<RankResponse> getAllRankFetchPointRate(){
+        List<Tuple> result = queryFactory
+                .select(rank.name,
+                        pointRate.earnPoint,
+                        pointRate.earnType)
                 .from(rank)
-                .leftJoin(rank.pointRate, pointRate).fetchJoin()
+                .leftJoin(rank.pointRate, pointRate)
+                .where(pointRate.applyType.eq(ApplyPointType.RANK))
                 .fetch();
+        List<RankResponse> rankResponses = new ArrayList<>();
+        for (Tuple tuple : result) {
+            rankResponses.add(RankResponse.builder()
+                    .name(tuple.get(rank.name))
+                    .earnPoint(tuple.get(pointRate.earnPoint))
+                    .earnType(tuple.get(pointRate.earnType))
+                    .build());
+        }
+
+        return rankResponses;
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/rank/repository/impl/RankRepositoryImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/rank/repository/impl/RankRepositoryImpl.java
@@ -4,6 +4,7 @@ import static shop.bookbom.shop.domain.pointrate.entity.QPointRate.pointRate;
 import static shop.bookbom.shop.domain.rank.entity.QRank.rank;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import shop.bookbom.shop.domain.rank.entity.Rank;
 import shop.bookbom.shop.domain.rank.exception.RankNotFoundException;
@@ -25,5 +26,14 @@ public class RankRepositoryImpl implements RankRepositoryCustom {
             throw new RankNotFoundException();
         }
         return result;
+    }
+
+    @Override
+    public List<Rank> getAllRankFetchPointRate(){
+        return queryFactory
+                .select(rank)
+                .from(rank)
+                .leftJoin(rank.pointRate, pointRate).fetchJoin()
+                .fetch();
     }
 }


### PR DESCRIPTION
# 설명
- 회원 등급 조회 구현

# 작업내용
- 회원 등급 조회 시 회원의 닉네임과 회원 랭크의 이름을 반환
 

(이슈에 대한 작업완료시) close #이슈번호
