### PR TITLE
[feat] 회원 주소록 기능 구현

### DIFF
--- a/src/main/java/shop/bookbom/shop/common/exception/ErrorCode.java
+++ b/src/main/java/shop/bookbom/shop/common/exception/ErrorCode.java
@@ -76,6 +76,8 @@ public enum ErrorCode {
     USER_NOT_VALIDATE(400, "아이디나 비밀번호가 일치하지 않습니다."),
     //rank
     RANK_NOT_FOUND(404, "해당 등급이 존재하지 않습니다."),
+    //address
+    ADDRESS_LIMIT_EXCEED(400, "주소록 최대 저장 갯수를 초과하였습니다."),
     ;
 
     private final int code;

--- a/src/main/java/shop/bookbom/shop/common/exception/ErrorCode.java
+++ b/src/main/java/shop/bookbom/shop/common/exception/ErrorCode.java
@@ -77,6 +77,7 @@ public enum ErrorCode {
     //rank
     RANK_NOT_FOUND(404, "해당 등급이 존재하지 않습니다."),
     //address
+    ADDRESS_NOT_FOUND(404, "해당 주소가 존재하지 않습니다."),
     ADDRESS_LIMIT_EXCEED(400, "주소록 최대 저장 갯수를 초과하였습니다."),
     ;
 

--- a/src/main/java/shop/bookbom/shop/common/exception/ErrorCode.java
+++ b/src/main/java/shop/bookbom/shop/common/exception/ErrorCode.java
@@ -80,6 +80,7 @@ public enum ErrorCode {
     ADDRESS_NOT_FOUND(404, "해당 주소가 존재하지 않습니다."),
     ADDRESS_LIMIT_EXCEED(400, "주소록 최대 저장 갯수를 초과하였습니다."),
     ADDRESS_ALREADY_EXIST(400, "이미 동일한 주소가 존재합니다."),
+    ADDRESS_DEFAULT_DELETE(400, "기본 주소지는 삭제할 수 없습니다."),
     ;
 
     private final int code;

--- a/src/main/java/shop/bookbom/shop/common/exception/ErrorCode.java
+++ b/src/main/java/shop/bookbom/shop/common/exception/ErrorCode.java
@@ -81,6 +81,7 @@ public enum ErrorCode {
     ADDRESS_LIMIT_EXCEED(400, "주소록 최대 저장 갯수를 초과하였습니다."),
     ADDRESS_ALREADY_EXIST(400, "이미 동일한 주소가 존재합니다."),
     ADDRESS_DEFAULT_DELETE(400, "기본 주소지는 삭제할 수 없습니다."),
+    ADDRESS_MINIMUM_REQUIRED(400, "주소록에 최소 1개 이상의 주소가 있어야 합니다."),
     ;
 
     private final int code;

--- a/src/main/java/shop/bookbom/shop/common/exception/ErrorCode.java
+++ b/src/main/java/shop/bookbom/shop/common/exception/ErrorCode.java
@@ -79,6 +79,7 @@ public enum ErrorCode {
     //address
     ADDRESS_NOT_FOUND(404, "해당 주소가 존재하지 않습니다."),
     ADDRESS_LIMIT_EXCEED(400, "주소록 최대 저장 갯수를 초과하였습니다."),
+    ADDRESS_ALREADY_EXIST(400, "이미 동일한 주소가 존재합니다."),
     ;
 
     private final int code;

--- a/src/main/java/shop/bookbom/shop/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/shop/bookbom/shop/common/exception/GlobalExceptionHandler.java
@@ -18,7 +18,7 @@ public class GlobalExceptionHandler {
         StringBuilder sb = new StringBuilder();
         e.getBindingResult()
                 .getAllErrors()
-                .forEach(error -> sb.append(error.getDefaultMessage()).append("\n"));
+                .forEach(error -> sb.append(error.getDefaultMessage()).append(","));
         return CommonResponse.fail(ErrorCode.COMMON_INVALID_PARAMETER, sb.toString());
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/address/controller/AddressController.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/controller/AddressController.java
@@ -3,6 +3,7 @@ package shop.bookbom.shop.domain.address.controller;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -54,6 +55,12 @@ public class AddressController {
         validSameAddress(userDto.getId(), request);
         addressService.updateAddress(id, request.getNickname(), request.getZipcode(), request.getAddress(),
                 request.getAddressDetail());
+        return CommonResponse.success();
+    }
+
+    @DeleteMapping("/{addressId}")
+    public CommonResponse<Void> deleteAddress(@PathVariable("addressId") Long id) {
+        addressService.deleteAddress(id);
         return CommonResponse.success();
     }
 

--- a/src/main/java/shop/bookbom/shop/domain/address/controller/AddressController.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/controller/AddressController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +33,12 @@ public class AddressController {
     public CommonResponse<Void> addAddress(@Login UserDto userDto, @Valid @RequestBody AddressSaveRequest request) {
         addressService.saveAddress(userDto.getId(), request.getNickname(), request.getZipcode(), request.getAddress(),
                 request.getAddressDetail());
+        return CommonResponse.success();
+    }
+
+    @PostMapping("/default/{addressId}")
+    public CommonResponse<Void> updateDefaultAddress(@Login UserDto userDto, @PathVariable("addressId") Long id) {
+        addressService.updateDefaultAddress(userDto.getId(), id);
         return CommonResponse.success();
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/address/controller/AddressController.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/controller/AddressController.java
@@ -1,12 +1,17 @@
 package shop.bookbom.shop.domain.address.controller;
 
 import java.util.List;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import shop.bookbom.shop.annotation.Login;
 import shop.bookbom.shop.common.CommonListResponse;
+import shop.bookbom.shop.common.CommonResponse;
+import shop.bookbom.shop.domain.address.dto.request.AddressSaveRequest;
 import shop.bookbom.shop.domain.address.dto.response.AddressResponse;
 import shop.bookbom.shop.domain.address.service.AddressServiceImpl;
 import shop.bookbom.shop.domain.users.dto.UserDto;
@@ -21,5 +26,12 @@ public class AddressController {
     public CommonListResponse<AddressResponse> getAddressBook(@Login UserDto userDto) {
         List<AddressResponse> addressBook = addressService.getAddressBook(userDto.getId());
         return CommonListResponse.successWithList(addressBook);
+    }
+
+    @PostMapping
+    public CommonResponse<Void> addAddress(@Login UserDto userDto, @Valid @RequestBody AddressSaveRequest request) {
+        addressService.saveAddress(userDto.getId(), request.getNickname(), request.getZipcode(), request.getAddress(),
+                request.getAddressDetail());
+        return CommonResponse.success();
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/address/controller/AddressController.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/controller/AddressController.java
@@ -59,8 +59,8 @@ public class AddressController {
     }
 
     @DeleteMapping("/{addressId}")
-    public CommonResponse<Void> deleteAddress(@PathVariable("addressId") Long id) {
-        addressService.deleteAddress(id);
+    public CommonResponse<Void> deleteAddress(@Login UserDto userDto, @PathVariable("addressId") Long id) {
+        addressService.deleteAddress(userDto.getId(), id);
         return CommonResponse.success();
     }
 

--- a/src/main/java/shop/bookbom/shop/domain/address/controller/AddressController.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/controller/AddressController.java
@@ -1,0 +1,25 @@
+package shop.bookbom.shop.domain.address.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shop.bookbom.shop.annotation.Login;
+import shop.bookbom.shop.common.CommonListResponse;
+import shop.bookbom.shop.domain.address.dto.response.AddressResponse;
+import shop.bookbom.shop.domain.address.service.AddressServiceImpl;
+import shop.bookbom.shop.domain.users.dto.UserDto;
+
+@RestController
+@RequestMapping("/shop/users/address")
+@RequiredArgsConstructor
+public class AddressController {
+    private final AddressServiceImpl addressService;
+
+    @GetMapping
+    public CommonListResponse<AddressResponse> getAddressBook(@Login UserDto userDto) {
+        List<AddressResponse> addressBook = addressService.getAddressBook(userDto.getId());
+        return CommonListResponse.successWithList(addressBook);
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/address/controller/AddressController.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/controller/AddressController.java
@@ -6,14 +6,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import shop.bookbom.shop.annotation.Login;
 import shop.bookbom.shop.common.CommonListResponse;
 import shop.bookbom.shop.common.CommonResponse;
-import shop.bookbom.shop.domain.address.dto.request.AddressSaveRequest;
+import shop.bookbom.shop.domain.address.dto.request.AddressRequest;
 import shop.bookbom.shop.domain.address.dto.response.AddressResponse;
+import shop.bookbom.shop.domain.address.exception.AddressAlreadyExistsException;
 import shop.bookbom.shop.domain.address.service.AddressServiceImpl;
 import shop.bookbom.shop.domain.users.dto.UserDto;
 
@@ -30,7 +32,8 @@ public class AddressController {
     }
 
     @PostMapping
-    public CommonResponse<Void> addAddress(@Login UserDto userDto, @Valid @RequestBody AddressSaveRequest request) {
+    public CommonResponse<Void> addAddress(@Login UserDto userDto, @Valid @RequestBody AddressRequest request) {
+        validSameAddress(userDto.getId(), request);
         addressService.saveAddress(userDto.getId(), request.getNickname(), request.getZipcode(), request.getAddress(),
                 request.getAddressDetail());
         return CommonResponse.success();
@@ -40,5 +43,30 @@ public class AddressController {
     public CommonResponse<Void> updateDefaultAddress(@Login UserDto userDto, @PathVariable("addressId") Long id) {
         addressService.updateDefaultAddress(userDto.getId(), id);
         return CommonResponse.success();
+    }
+
+    @PutMapping("/{addressId}")
+    public CommonResponse<Void> updateAddress(
+            @Login UserDto userDto,
+            @PathVariable("addressId") Long id,
+            @Valid @RequestBody AddressRequest request
+    ) {
+        validSameAddress(userDto.getId(), request);
+        addressService.updateAddress(id, request.getNickname(), request.getZipcode(), request.getAddress(),
+                request.getAddressDetail());
+        return CommonResponse.success();
+    }
+
+    /**
+     * 동일한 주소가 있는지 확인하는 메서드입니다.
+     *
+     * @param id      주소 ID
+     * @param request 주소 요청
+     */
+    private void validSameAddress(Long id, AddressRequest request) {
+        if (addressService.existsSameAddress(id, request.getZipcode(), request.getAddress(),
+                request.getAddressDetail())) {
+            throw new AddressAlreadyExistsException();
+        }
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/address/dto/request/AddressRequest.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/dto/request/AddressRequest.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class AddressSaveRequest {
+public class AddressRequest {
     private String nickname;
     @Size(min = 5, max = 5, message = "우편번호는 5자리여야 합니다.")
     private String zipcode;

--- a/src/main/java/shop/bookbom/shop/domain/address/dto/request/AddressSaveRequest.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/dto/request/AddressSaveRequest.java
@@ -1,0 +1,18 @@
+package shop.bookbom.shop.domain.address.dto.request;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AddressSaveRequest {
+    private String nickname;
+    @Size(min = 5, max = 5, message = "우편번호는 5자리여야 합니다.")
+    private String zipcode;
+    @NotEmpty(message = "주소를 입력해주세요.")
+    private String address;
+    @NotEmpty(message = "상세 주소를 입력해주세요.")
+    private String addressDetail;
+}

--- a/src/main/java/shop/bookbom/shop/domain/address/dto/response/AddressResponse.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/dto/response/AddressResponse.java
@@ -1,0 +1,28 @@
+package shop.bookbom.shop.domain.address.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import shop.bookbom.shop.domain.address.entity.Address;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AddressResponse {
+    private Long id;
+    private String nickname;
+    private String zipCode;
+    private String address;
+    private String addressDetail;
+    private boolean defaultAddress;
+
+    public static AddressResponse from(Address address) {
+        return new AddressResponse(
+                address.getId(),
+                address.getNickname(),
+                address.getZipCode(),
+                address.getAddress(),
+                address.getAddressDetail(),
+                address.isDefaultAddress()
+        );
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/address/entity/Address.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/entity/Address.java
@@ -56,8 +56,8 @@ public class Address {
         this.member = member;
     }
 
-    public void setDefaultAddress() {
-        this.defaultAddress = true;
+    public void updateDefaultAddress(boolean defaultAddress) {
+        this.defaultAddress = defaultAddress;
     }
 
     public void updateNickname(String nickname) {

--- a/src/main/java/shop/bookbom/shop/domain/address/entity/Address.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/entity/Address.java
@@ -63,4 +63,11 @@ public class Address {
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
+
+    public void updateAddress(String nickname, String zipcode, String address, String addressDetail) {
+        this.nickname = nickname;
+        this.zipCode = zipcode;
+        this.address = address;
+        this.addressDetail = addressDetail;
+    }
 }

--- a/src/main/java/shop/bookbom/shop/domain/address/entity/Address.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/entity/Address.java
@@ -55,12 +55,12 @@ public class Address {
         this.defaultAddress = defaultAddress;
         this.member = member;
     }
-    
+
     public void setDefaultAddress() {
         this.defaultAddress = true;
     }
 
-    public void editNickName(String nickName) {
-        this.nickname = nickName;
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/address/exception/AddressAlreadyExistsException.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/exception/AddressAlreadyExistsException.java
@@ -1,0 +1,10 @@
+package shop.bookbom.shop.domain.address.exception;
+
+import shop.bookbom.shop.common.exception.BaseException;
+import shop.bookbom.shop.common.exception.ErrorCode;
+
+public class AddressAlreadyExistsException extends BaseException {
+    public AddressAlreadyExistsException() {
+        super(ErrorCode.ADDRESS_ALREADY_EXIST);
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/address/exception/AddressDefaultDeleteException.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/exception/AddressDefaultDeleteException.java
@@ -1,0 +1,10 @@
+package shop.bookbom.shop.domain.address.exception;
+
+import shop.bookbom.shop.common.exception.BaseException;
+import shop.bookbom.shop.common.exception.ErrorCode;
+
+public class AddressDefaultDeleteException extends BaseException {
+    public AddressDefaultDeleteException() {
+        super(ErrorCode.ADDRESS_DEFAULT_DELETE);
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/address/exception/AddressLimitExceedException.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/exception/AddressLimitExceedException.java
@@ -1,0 +1,10 @@
+package shop.bookbom.shop.domain.address.exception;
+
+import shop.bookbom.shop.common.exception.BaseException;
+import shop.bookbom.shop.common.exception.ErrorCode;
+
+public class AddressLimitExceedException extends BaseException {
+    public AddressLimitExceedException() {
+        super(ErrorCode.ADDRESS_LIMIT_EXCEED);
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/address/exception/AddressMinimumRequiredException.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/exception/AddressMinimumRequiredException.java
@@ -1,0 +1,10 @@
+package shop.bookbom.shop.domain.address.exception;
+
+import shop.bookbom.shop.common.exception.BaseException;
+import shop.bookbom.shop.common.exception.ErrorCode;
+
+public class AddressMinimumRequiredException extends BaseException {
+    public AddressMinimumRequiredException() {
+        super(ErrorCode.ADDRESS_MINIMUM_REQUIRED);
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/address/exception/AddressNotFoundException.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/exception/AddressNotFoundException.java
@@ -1,0 +1,10 @@
+package shop.bookbom.shop.domain.address.exception;
+
+import shop.bookbom.shop.common.exception.BaseException;
+import shop.bookbom.shop.common.exception.ErrorCode;
+
+public class AddressNotFoundException extends BaseException {
+    public AddressNotFoundException() {
+        super(ErrorCode.ADDRESS_NOT_FOUND);
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/address/repository/AddressRepository.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/repository/AddressRepository.java
@@ -1,7 +1,10 @@
 package shop.bookbom.shop.domain.address.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import shop.bookbom.shop.domain.address.entity.Address;
+import shop.bookbom.shop.domain.member.entity.Member;
 
 public interface AddressRepository extends JpaRepository<Address, Long> {
+    List<Address> findByMember(Member member);
 }

--- a/src/main/java/shop/bookbom/shop/domain/address/repository/AddressRepository.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/repository/AddressRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import shop.bookbom.shop.domain.address.entity.Address;
 import shop.bookbom.shop.domain.member.entity.Member;
 
-public interface AddressRepository extends JpaRepository<Address, Long> {
+public interface AddressRepository extends JpaRepository<Address, Long>, AddressRepositoryCustom {
     List<Address> findByMember(Member member);
+
+    long countByMember(Member member);
 }

--- a/src/main/java/shop/bookbom/shop/domain/address/repository/AddressRepositoryCustom.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/repository/AddressRepositoryCustom.java
@@ -1,0 +1,17 @@
+package shop.bookbom.shop.domain.address.repository;
+
+import shop.bookbom.shop.domain.address.entity.Address;
+import shop.bookbom.shop.domain.member.entity.Member;
+
+public interface AddressRepositoryCustom {
+    /**
+     * 동일한 주소가 있는지 확인하는 메서드입니다.
+     *
+     * @param member        회원
+     * @param address       주소
+     * @param addressDetail 상세 주소
+     * @param zipCode       우편번호
+     * @return 동일한 주소가 있으면 반환하고 없으면 null을 반환합니다.
+     */
+    Address findSameAddress(Member member, String address, String addressDetail, String zipCode);
+}

--- a/src/main/java/shop/bookbom/shop/domain/address/repository/AddressRepositoryCustom.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/repository/AddressRepositoryCustom.java
@@ -1,6 +1,5 @@
 package shop.bookbom.shop.domain.address.repository;
 
-import shop.bookbom.shop.domain.address.entity.Address;
 import shop.bookbom.shop.domain.member.entity.Member;
 
 public interface AddressRepositoryCustom {
@@ -13,5 +12,5 @@ public interface AddressRepositoryCustom {
      * @param zipCode       우편번호
      * @return 동일한 주소가 있으면 반환하고 없으면 null을 반환합니다.
      */
-    Address findSameAddress(Member member, String address, String addressDetail, String zipCode);
+    boolean existsSameAddress(Member member, String address, String addressDetail, String zipCode);
 }

--- a/src/main/java/shop/bookbom/shop/domain/address/repository/impl/AddressRepositoryImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/repository/impl/AddressRepositoryImpl.java
@@ -4,7 +4,6 @@ import static shop.bookbom.shop.domain.address.entity.QAddress.address1;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import shop.bookbom.shop.domain.address.entity.Address;
 import shop.bookbom.shop.domain.address.repository.AddressRepositoryCustom;
 import shop.bookbom.shop.domain.member.entity.Member;
 
@@ -13,16 +12,16 @@ public class AddressRepositoryImpl implements AddressRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Address findSameAddress(Member member, String address, String addressDetail, String zipCode) {
-        return queryFactory
-                .select(address1)
+    public boolean existsSameAddress(Member member, String address, String addressDetail, String zipCode) {
+        Integer result = queryFactory
+                .selectOne()
                 .from(address1)
                 .where(
                         address1.member.eq(member)
-                                .and(address1.zipCode.eq(zipCode))
                                 .and(address1.address.eq(address))
                                 .and(address1.addressDetail.eq(addressDetail))
                 )
-                .fetchOne();
+                .fetchFirst();
+        return result != null;
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/address/repository/impl/AddressRepositoryImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/repository/impl/AddressRepositoryImpl.java
@@ -1,0 +1,28 @@
+package shop.bookbom.shop.domain.address.repository.impl;
+
+import static shop.bookbom.shop.domain.address.entity.QAddress.address1;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import shop.bookbom.shop.domain.address.entity.Address;
+import shop.bookbom.shop.domain.address.repository.AddressRepositoryCustom;
+import shop.bookbom.shop.domain.member.entity.Member;
+
+@RequiredArgsConstructor
+public class AddressRepositoryImpl implements AddressRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Address findSameAddress(Member member, String address, String addressDetail, String zipCode) {
+        return queryFactory
+                .select(address1)
+                .from(address1)
+                .where(
+                        address1.member.eq(member)
+                                .and(address1.zipCode.eq(zipCode))
+                                .and(address1.address.eq(address))
+                                .and(address1.addressDetail.eq(addressDetail))
+                )
+                .fetchOne();
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/address/service/AddressService.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/service/AddressService.java
@@ -46,11 +46,18 @@ public interface AddressService {
     /**
      * 동일한 주소가 있는지 확인하는 메서드입니다.
      *
-     * @param memberId      회원 ID
+     * @param userId        회원 ID
      * @param zipCode       우편번호
      * @param address       주소
      * @param addressDetail 상세주소
      * @return 동일한 주소가 있으면 true, 없으면 false
      */
-    boolean existsSameAddress(Long memberId, String zipCode, String address, String addressDetail);
+    boolean existsSameAddress(Long userId, String zipCode, String address, String addressDetail);
+
+    /**
+     * 주소를 삭제하는 메서드입니다.
+     *
+     * @param addressId 주소 ID
+     */
+    void deleteAddress(Long addressId);
 }

--- a/src/main/java/shop/bookbom/shop/domain/address/service/AddressService.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/service/AddressService.java
@@ -11,4 +11,15 @@ public interface AddressService {
      * @return 주소록
      */
     List<AddressResponse> getAddressBook(Long userId);
+
+    /**
+     * 주소를 저장하는 메서드입니다.
+     *
+     * @param userId        회원 ID
+     * @param nickname      별칭
+     * @param zipCode       우편번호
+     * @param address       주소
+     * @param addressDetail 상세주소
+     */
+    void saveAddress(Long userId, String nickname, String zipCode, String address, String addressDetail);
 }

--- a/src/main/java/shop/bookbom/shop/domain/address/service/AddressService.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/service/AddressService.java
@@ -22,4 +22,12 @@ public interface AddressService {
      * @param addressDetail 상세주소
      */
     void saveAddress(Long userId, String nickname, String zipCode, String address, String addressDetail);
+
+    /**
+     * 기본 배송지를 변경하는 메서드입니다.
+     *
+     * @param userId    회원 ID
+     * @param addressId 주소 ID
+     */
+    void updateDefaultAddress(Long userId, Long addressId);
 }

--- a/src/main/java/shop/bookbom/shop/domain/address/service/AddressService.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/service/AddressService.java
@@ -30,4 +30,27 @@ public interface AddressService {
      * @param addressId 주소 ID
      */
     void updateDefaultAddress(Long userId, Long addressId);
+
+    /**
+     * 주소를 수정하는 메서드입니다.
+     *
+     * @param id            주소 ID
+     * @param nickname      별칭
+     * @param zipcode       우편번호
+     * @param address       주소
+     * @param addressDetail 상세주소
+     */
+    void updateAddress(Long id, String nickname, String zipcode, String address,
+                       String addressDetail);
+
+    /**
+     * 동일한 주소가 있는지 확인하는 메서드입니다.
+     *
+     * @param memberId      회원 ID
+     * @param zipCode       우편번호
+     * @param address       주소
+     * @param addressDetail 상세주소
+     * @return 동일한 주소가 있으면 true, 없으면 false
+     */
+    boolean existsSameAddress(Long memberId, String zipCode, String address, String addressDetail);
 }

--- a/src/main/java/shop/bookbom/shop/domain/address/service/AddressService.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/service/AddressService.java
@@ -1,0 +1,14 @@
+package shop.bookbom.shop.domain.address.service;
+
+import java.util.List;
+import shop.bookbom.shop.domain.address.dto.response.AddressResponse;
+
+public interface AddressService {
+    /**
+     * 회원의 주소록을 반환하는 메서드입니다.
+     *
+     * @param userId 회원 ID
+     * @return 주소록
+     */
+    List<AddressResponse> getAddressBook(Long userId);
+}

--- a/src/main/java/shop/bookbom/shop/domain/address/service/AddressService.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/service/AddressService.java
@@ -57,7 +57,8 @@ public interface AddressService {
     /**
      * 주소를 삭제하는 메서드입니다.
      *
+     * @param userId    회원 ID
      * @param addressId 주소 ID
      */
-    void deleteAddress(Long addressId);
+    void deleteAddress(Long userId, Long addressId);
 }

--- a/src/main/java/shop/bookbom/shop/domain/address/service/AddressServiceImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/service/AddressServiceImpl.java
@@ -38,11 +38,6 @@ public class AddressServiceImpl implements AddressService {
         Member member = memberRepository.findById(userId)
                 .orElseThrow(MemberNotFoundException::new);
         checkAddressCount(member);
-        Address sameAddress = addressRepository.findSameAddress(member, address, addressDetail, zipCode);
-        if (sameAddress != null) {
-            sameAddress.updateNickname(nickname);
-            return;
-        }
         Address newAddress = Address.builder()
                 .member(member)
                 .nickname(nickname)
@@ -51,6 +46,14 @@ public class AddressServiceImpl implements AddressService {
                 .addressDetail(addressDetail)
                 .build();
         addressRepository.save(newAddress);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean existsSameAddress(Long memberId, String zipCode, String address, String addressDetail) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+        return addressRepository.existsSameAddress(member, zipCode, address, addressDetail);
     }
 
     @Override
@@ -63,6 +66,15 @@ public class AddressServiceImpl implements AddressService {
                 .findFirst()
                 .orElseThrow(AddressNotFoundException::new);
         addresses.forEach(a -> a.updateDefaultAddress(a.equals(findAddress)));
+    }
+
+    @Override
+    @Transactional
+    public void updateAddress(Long id, String nickname, String zipcode, String address,
+                              String addressDetail) {
+        Address findAddress = addressRepository.findById(id)
+                .orElseThrow(AddressNotFoundException::new);
+        findAddress.updateAddress(nickname, zipcode, address, addressDetail);
     }
 
     /**

--- a/src/main/java/shop/bookbom/shop/domain/address/service/AddressServiceImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/service/AddressServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.bookbom.shop.domain.address.dto.response.AddressResponse;
 import shop.bookbom.shop.domain.address.entity.Address;
+import shop.bookbom.shop.domain.address.exception.AddressLimitExceedException;
 import shop.bookbom.shop.domain.address.repository.AddressRepository;
 import shop.bookbom.shop.domain.member.entity.Member;
 import shop.bookbom.shop.domain.member.exception.MemberNotFoundException;
@@ -15,6 +16,7 @@ import shop.bookbom.shop.domain.member.repository.MemberRepository;
 @Service
 @RequiredArgsConstructor
 public class AddressServiceImpl implements AddressService {
+    private static final int MAX_ADDRESS_COUNT = 10;
     private final AddressRepository addressRepository;
     private final MemberRepository memberRepository;
 
@@ -27,5 +29,38 @@ public class AddressServiceImpl implements AddressService {
         return addresses.stream()
                 .map(AddressResponse::from)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void saveAddress(Long userId, String nickname, String zipCode, String address, String addressDetail) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(MemberNotFoundException::new);
+        checkAddressCount(member);
+        Address sameAddress = addressRepository.findSameAddress(member, address, addressDetail, zipCode);
+        if (sameAddress != null) {
+            sameAddress.updateNickname(nickname);
+            return;
+        }
+        Address newAddress = Address.builder()
+                .member(member)
+                .nickname(nickname)
+                .zipCode(zipCode)
+                .address(address)
+                .addressDetail(addressDetail)
+                .build();
+        addressRepository.save(newAddress);
+    }
+
+    /**
+     * 주소록 갯수를 확인해 최대 주소록 갯수를 초과하면 예외를 발생시키는 메서드입니다.
+     *
+     * @param member 회원
+     */
+    private void checkAddressCount(Member member) {
+        long count = addressRepository.countByMember(member);
+        if (count >= MAX_ADDRESS_COUNT) {
+            throw new AddressLimitExceedException();
+        }
     }
 }

--- a/src/main/java/shop/bookbom/shop/domain/address/service/AddressServiceImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/service/AddressServiceImpl.java
@@ -1,0 +1,31 @@
+package shop.bookbom.shop.domain.address.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.bookbom.shop.domain.address.dto.response.AddressResponse;
+import shop.bookbom.shop.domain.address.entity.Address;
+import shop.bookbom.shop.domain.address.repository.AddressRepository;
+import shop.bookbom.shop.domain.member.entity.Member;
+import shop.bookbom.shop.domain.member.exception.MemberNotFoundException;
+import shop.bookbom.shop.domain.member.repository.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
+public class AddressServiceImpl implements AddressService {
+    private final AddressRepository addressRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AddressResponse> getAddressBook(Long userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(MemberNotFoundException::new);
+        List<Address> addresses = addressRepository.findByMember(member);
+        return addresses.stream()
+                .map(AddressResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/shop/bookbom/shop/domain/address/service/AddressServiceImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/service/AddressServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import shop.bookbom.shop.domain.address.dto.response.AddressResponse;
 import shop.bookbom.shop.domain.address.entity.Address;
 import shop.bookbom.shop.domain.address.exception.AddressLimitExceedException;
+import shop.bookbom.shop.domain.address.exception.AddressNotFoundException;
 import shop.bookbom.shop.domain.address.repository.AddressRepository;
 import shop.bookbom.shop.domain.member.entity.Member;
 import shop.bookbom.shop.domain.member.exception.MemberNotFoundException;
@@ -50,6 +51,18 @@ public class AddressServiceImpl implements AddressService {
                 .addressDetail(addressDetail)
                 .build();
         addressRepository.save(newAddress);
+    }
+
+    @Override
+    @Transactional
+    public void updateDefaultAddress(Long userId, Long addressId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(MemberNotFoundException::new);
+        List<Address> addresses = addressRepository.findByMember(member);
+        Address findAddress = addresses.stream().filter(a -> a.getId().equals(addressId))
+                .findFirst()
+                .orElseThrow(AddressNotFoundException::new);
+        addresses.forEach(a -> a.updateDefaultAddress(a.equals(findAddress)));
     }
 
     /**

--- a/src/main/java/shop/bookbom/shop/domain/address/service/AddressServiceImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/address/service/AddressServiceImpl.java
@@ -9,6 +9,7 @@ import shop.bookbom.shop.domain.address.dto.response.AddressResponse;
 import shop.bookbom.shop.domain.address.entity.Address;
 import shop.bookbom.shop.domain.address.exception.AddressDefaultDeleteException;
 import shop.bookbom.shop.domain.address.exception.AddressLimitExceedException;
+import shop.bookbom.shop.domain.address.exception.AddressMinimumRequiredException;
 import shop.bookbom.shop.domain.address.exception.AddressNotFoundException;
 import shop.bookbom.shop.domain.address.repository.AddressRepository;
 import shop.bookbom.shop.domain.member.entity.Member;
@@ -60,7 +61,13 @@ public class AddressServiceImpl implements AddressService {
 
     @Override
     @Transactional
-    public void deleteAddress(Long addressId) {
+    public void deleteAddress(Long userId, Long addressId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(MemberNotFoundException::new);
+        long count = addressRepository.countByMember(member);
+        if (count <= 1) {
+            throw new AddressMinimumRequiredException();
+        }
         Address address = addressRepository.findById(addressId)
                 .orElseThrow(AddressNotFoundException::new);
         if (address.isDefaultAddress()) {
@@ -95,7 +102,7 @@ public class AddressServiceImpl implements AddressService {
      *
      * @param count 주소록 갯수
      */
-    public void validAddressCount(long count) {
+    private void validAddressCount(long count) {
         if (count >= MAX_ADDRESS_COUNT) {
             throw new AddressLimitExceedException();
         }


### PR DESCRIPTION
# 설명
회원 주소록 기능을 구현하였습니다

# 작업내용
- 회원의 주소 목록을 조회할 수 있습니다.
- 카카오 주소 API를 이용해 주소를 등록할 수 있습니다.
  - 주소 등록은 최대 10개까지 가능합니다.
- 기본 배송지로 설정할 주소를 선택할 수 있습니다.
- 주소록에서 주소를 삭제할 수 있습니다.
  - 기본 배송지로 설정된 주소는 삭제할 수 없습니다.
  - 주소록에 주소가 하나만 있을 경우 삭제할 수 없습니다. 