### PR TITLE
[fix] 로그인 userId 조회 로직 수정

### DIFF
--- a/src/main/java/shop/bookbom/shop/ShopApplication.java
+++ b/src/main/java/shop/bookbom/shop/ShopApplication.java
@@ -2,12 +2,14 @@ package shop.bookbom.shop;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @EnableDiscoveryClient
 @EnableFeignClients
+@ConfigurationPropertiesScan
 public class ShopApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/shop/bookbom/shop/argumentresolver/LoginArgumentResolver.java
+++ b/src/main/java/shop/bookbom/shop/argumentresolver/LoginArgumentResolver.java
@@ -1,22 +1,25 @@
 package shop.bookbom.shop.argumentresolver;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import shop.bookbom.shop.annotation.Login;
+import shop.bookbom.shop.config.JwtSecretKeyProperties;
 import shop.bookbom.shop.domain.users.dto.UserDto;
-import shop.bookbom.shop.domain.users.dto.response.UserIdRole;
-import shop.bookbom.shop.security.jwt.JwtConfig;
 
 @Slf4j
+@Component
 @RequiredArgsConstructor
 public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
-    private final JwtConfig jwtConfig;
+    private final JwtSecretKeyProperties jwtSecretKeyProperties;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -34,8 +37,21 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
             WebDataBinderFactory binderFactory
     ) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        String token = jwtConfig.resolveToken(request);
-        UserIdRole userIdRole = jwtConfig.getUserIdRole(token);
-        return new UserDto(userIdRole.getUserId());
+        String authorization = request.getHeader("Authorization");
+        if (authorization == null || authorization.isBlank() || !authorization.contains("Bearer ")) {
+            return null;
+        }
+        String token = authorization.replace("Bearer ", "");
+        String secretKey = jwtSecretKeyProperties.getSecretKey();
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey.getBytes())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        if (claims == null || claims.isEmpty()) {
+            return null;
+        }
+        Long userId = claims.get("userId", Long.class);
+        return new UserDto(userId);
     }
 }

--- a/src/main/java/shop/bookbom/shop/config/JwtSecretKeyProperties.java
+++ b/src/main/java/shop/bookbom/shop/config/JwtSecretKeyProperties.java
@@ -1,0 +1,14 @@
+package shop.bookbom.shop.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@Getter
+@ConfigurationProperties(prefix = "jwt")
+@ConstructorBinding
+@RequiredArgsConstructor
+public class JwtSecretKeyProperties {
+    private final String secretKey;
+}

--- a/src/main/java/shop/bookbom/shop/config/SecurityConfig.java
+++ b/src/main/java/shop/bookbom/shop/config/SecurityConfig.java
@@ -17,11 +17,14 @@ import shop.bookbom.shop.security.jwt.JwtConfig;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private final JwtConfig jwtConfig;
+    @Bean
+    public JwtConfig jwtConfig() {
+        return new JwtConfig();
+    }
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(jwtConfig);
+        return new JwtAuthenticationFilter(jwtConfig());
     }
 
     @Bean

--- a/src/main/java/shop/bookbom/shop/config/WebConfig.java
+++ b/src/main/java/shop/bookbom/shop/config/WebConfig.java
@@ -2,23 +2,18 @@ package shop.bookbom.shop.config;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import shop.bookbom.shop.argumentresolver.LoginArgumentResolver;
-import shop.bookbom.shop.security.jwt.JwtConfig;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
-    @Bean
-    public JwtConfig jwtConfig() {
-        return new JwtConfig();
-    }
+    private final JwtSecretKeyProperties jwtSecretKeyProperties;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new LoginArgumentResolver(jwtConfig()));
+        resolvers.add(new LoginArgumentResolver(jwtSecretKeyProperties));
     }
 }

--- a/src/test/java/shop/bookbom/shop/domain/book/controller/AdminBookControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/book/controller/AdminBookControllerTest.java
@@ -23,6 +23,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -30,6 +32,8 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import shop.bookbom.shop.argumentresolver.LoginArgumentResolver;
+import shop.bookbom.shop.config.WebConfig;
 import shop.bookbom.shop.domain.book.dto.request.BookAddRequest;
 import shop.bookbom.shop.domain.book.dto.request.BookUpdateRequest;
 import shop.bookbom.shop.domain.book.service.BookService;
@@ -47,7 +51,9 @@ import shop.bookbom.shop.domain.book.service.BookService;
  */
 @AutoConfigureMockMvc(addFilters = false)
 @ExtendWith(MockitoExtension.class)
-@WebMvcTest(AdminBookController.class)
+@WebMvcTest(value = AdminBookController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                classes = {WebConfig.class, LoginArgumentResolver.class}))
 class AdminBookControllerTest {
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/shop/bookbom/shop/domain/book/controller/OpenBookControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/book/controller/OpenBookControllerTest.java
@@ -25,12 +25,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import shop.bookbom.shop.argumentresolver.LoginArgumentResolver;
+import shop.bookbom.shop.config.WebConfig;
 import shop.bookbom.shop.domain.book.dto.BookSearchResponse;
 import shop.bookbom.shop.domain.book.dto.response.BookDetailResponse;
 import shop.bookbom.shop.domain.book.dto.response.BookMediumResponse;
@@ -51,7 +55,9 @@ import shop.bookbom.shop.domain.book.service.BookService;
  */
 @AutoConfigureMockMvc(addFilters = false)
 @ExtendWith(MockitoExtension.class)
-@WebMvcTest(OpenBookController.class)
+@WebMvcTest(value = OpenBookController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                classes = {WebConfig.class, LoginArgumentResolver.class}))
 class OpenBookControllerTest {
 
     @Autowired

--- a/src/test/java/shop/bookbom/shop/domain/booktag/controller/BookTagControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/booktag/controller/BookTagControllerTest.java
@@ -19,15 +19,21 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import shop.bookbom.shop.argumentresolver.LoginArgumentResolver;
+import shop.bookbom.shop.config.WebConfig;
 import shop.bookbom.shop.domain.booktag.dto.response.BookTagInfoResponse;
 import shop.bookbom.shop.domain.booktag.service.BookTagService;
 import shop.bookbom.shop.domain.category.entity.Status;
 
 @AutoConfigureMockMvc(addFilters = false)
 @ExtendWith(MockitoExtension.class)
-@WebMvcTest(BookTagController.class)
+@WebMvcTest(value = BookTagController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                classes = {WebConfig.class, LoginArgumentResolver.class}))
 class BookTagControllerTest {
 
     @Autowired

--- a/src/test/java/shop/bookbom/shop/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/member/controller/MemberControllerTest.java
@@ -36,7 +36,8 @@ import shop.bookbom.shop.domain.users.dto.UserDto;
 @ExtendWith(MockitoExtension.class)
 @WebMvcTest(
         value = MemberController.class,
-        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class))
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                classes = {WebConfig.class, LoginArgumentResolver.class}))
 class MemberControllerTest {
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/shop/bookbom/shop/domain/order/controller/OpenOrderControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/order/controller/OpenOrderControllerTest.java
@@ -19,11 +19,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import shop.bookbom.shop.argumentresolver.LoginArgumentResolver;
 import shop.bookbom.shop.common.exception.ErrorCode;
+import shop.bookbom.shop.config.WebConfig;
 import shop.bookbom.shop.domain.order.dto.request.BeforeOrderRequest;
 import shop.bookbom.shop.domain.order.dto.request.BeforeOrderRequestList;
 import shop.bookbom.shop.domain.order.dto.request.WrapperSelectBookRequest;
@@ -37,8 +41,12 @@ import shop.bookbom.shop.domain.wrapper.dto.WrapperDto;
 
 @AutoConfigureMockMvc(addFilters = false)
 @ExtendWith(MockitoExtension.class)
-@WebMvcTest(OpenOrderController.class)
-public class OpenOrderControllerTest {
+@WebMvcTest(
+        value = OpenOrderController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                classes = {WebConfig.class, LoginArgumentResolver.class})
+)
+class OpenOrderControllerTest {
 
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/shop/bookbom/shop/domain/pointhistory/controller/PointHistoryControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/pointhistory/controller/PointHistoryControllerTest.java
@@ -38,7 +38,8 @@ import shop.bookbom.shop.domain.users.dto.UserDto;
 @ExtendWith(MockitoExtension.class)
 @WebMvcTest(
         value = PointHistoryController.class,
-        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class))
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                classes = {WebConfig.class, LoginArgumentResolver.class}))
 class PointHistoryControllerTest {
 
     @Autowired

--- a/src/test/java/shop/bookbom/shop/domain/pointrate/controller/PointRateControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/pointrate/controller/PointRateControllerTest.java
@@ -20,10 +20,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import shop.bookbom.shop.argumentresolver.LoginArgumentResolver;
+import shop.bookbom.shop.config.WebConfig;
 import shop.bookbom.shop.domain.pointrate.dto.request.PointRateUpdateRequest;
 import shop.bookbom.shop.domain.pointrate.entity.EarnPointType;
 import shop.bookbom.shop.domain.pointrate.repository.dto.PointRateResponse;
@@ -31,7 +35,9 @@ import shop.bookbom.shop.domain.pointrate.service.PointRateService;
 
 @AutoConfigureMockMvc(addFilters = false)
 @ExtendWith(MockitoExtension.class)
-@WebMvcTest(PointRateController.class)
+@WebMvcTest(value = PointRateController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                classes = {WebConfig.class, LoginArgumentResolver.class}))
 class PointRateControllerTest {
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/shop/bookbom/shop/domain/rank/repository/RankRepository.java
+++ b/src/test/java/shop/bookbom/shop/domain/rank/repository/RankRepository.java
@@ -1,7 +1,0 @@
-package shop.bookbom.shop.domain.rank.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import shop.bookbom.shop.domain.rank.entity.Rank;
-
-public interface RankRepository extends JpaRepository<Rank, Long> {
-}

--- a/src/test/java/shop/bookbom/shop/domain/tag/controller/TagControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/tag/controller/TagControllerTest.java
@@ -15,14 +15,20 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import shop.bookbom.shop.argumentresolver.LoginArgumentResolver;
+import shop.bookbom.shop.config.WebConfig;
 import shop.bookbom.shop.domain.category.entity.Status;
 import shop.bookbom.shop.domain.tag.service.TagService;
 
 @AutoConfigureMockMvc(addFilters = false)
 @ExtendWith(MockitoExtension.class)
-@WebMvcTest(TagController.class)
+@WebMvcTest(value = TagController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                classes = {WebConfig.class, LoginArgumentResolver.class}))
 class TagControllerTest {
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/shop/bookbom/shop/domain/user/controller/OpenUserControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/user/controller/OpenUserControllerTest.java
@@ -14,14 +14,20 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.test.web.servlet.MockMvc;
+import shop.bookbom.shop.argumentresolver.LoginArgumentResolver;
+import shop.bookbom.shop.config.WebConfig;
 import shop.bookbom.shop.domain.member.service.MemberService;
 import shop.bookbom.shop.domain.users.controller.OpenUserController;
 import shop.bookbom.shop.domain.users.service.UserService;
 
 @AutoConfigureMockMvc(addFilters = false)
 @ExtendWith(MockitoExtension.class)
-@WebMvcTest(OpenUserController.class)
+@WebMvcTest(value = OpenUserController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                classes = {WebConfig.class, LoginArgumentResolver.class}))
 class OpenUserControllerTest {
 
     @Autowired

--- a/src/test/java/shop/bookbom/shop/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/user/controller/UserControllerTest.java
@@ -52,7 +52,8 @@ import shop.bookbom.shop.domain.users.service.UserService;
 @ExtendWith(MockitoExtension.class)
 @WebMvcTest(
         value = UserController.class,
-        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class))
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                classes = {WebConfig.class, LoginArgumentResolver.class}))
 class UserControllerTest {
 
     @Autowired


### PR DESCRIPTION
# 설명
- LoginArgumentResolver에서 로그인되지 않은 상태일 경우 null을 반환하도록 수정했습니다.
- 컨트롤러 테스트들에서 `@WebMvcTest`를 사용할 경우 LoginArgumentResolver 빈 등록을 제외하도록 설정했습니다.