### PR TITLE
[fix] 장바구니 회원 로직 수정

### DIFF
--- a/src/main/java/shop/bookbom/shop/domain/cart/controller/CartController.java
+++ b/src/main/java/shop/bookbom/shop/domain/cart/controller/CartController.java
@@ -69,10 +69,11 @@ public class CartController {
      */
     @PutMapping("/carts/items/{id}")
     public CommonResponse<CartUpdateResponse> updateQuantity(
+            @Login UserDto userDto,
             @PathVariable("id") Long id,
             @RequestBody @Valid CartUpdateRequest request
     ) {
-        return successWithData(cartService.updateQuantity(id, request.getQuantity()));
+        return successWithData(cartService.updateQuantity(userDto.getId(), id, request.getQuantity()));
     }
 
     /**
@@ -81,8 +82,8 @@ public class CartController {
      * @param id 장바구니 상품 ID
      */
     @DeleteMapping("/carts/items/{id}")
-    public CommonResponse<Void> deleteItem(@PathVariable("id") Long id) {
-        cartService.deleteItem(id);
+    public CommonResponse<Void> deleteItem(@Login UserDto userDto, @PathVariable("id") Long id) {
+        cartService.deleteItem(userDto.getId(), id);
         return success();
     }
 

--- a/src/main/java/shop/bookbom/shop/domain/cart/service/CartService.java
+++ b/src/main/java/shop/bookbom/shop/domain/cart/service/CartService.java
@@ -27,16 +27,17 @@ public interface CartService {
     /**
      * 장바구니 상품 수량을 변경하는 메서드입니다.
      *
-     * @param id       장바구니 상품 ID
+     * @param userId   회원 ID
+     * @param bookId   장바구니 상품 ID
      * @param quantity 변경할 수량
      * @return 변경 완료된 수량
      */
-    CartUpdateResponse updateQuantity(Long id, int quantity);
+    CartUpdateResponse updateQuantity(Long userId, Long bookId, int quantity);
 
     /**
      * 장바구니 상품을 삭제하는 메서드입니다.
      *
-     * @param id 장바구니 상품 ID
+     * @param bookId 장바구니 상품 ID
      */
-    void deleteItem(Long id);
+    void deleteItem(Long userId, Long bookId);
 }

--- a/src/main/java/shop/bookbom/shop/domain/cart/service/impl/CartServiceImpl.java
+++ b/src/main/java/shop/bookbom/shop/domain/cart/service/impl/CartServiceImpl.java
@@ -72,8 +72,11 @@ public class CartServiceImpl implements CartService {
 
     @Override
     @Transactional
-    public CartUpdateResponse updateQuantity(Long id, int quantity) {
-        CartItem cartItem = cartItemRepository.findById(id)
+    public CartUpdateResponse updateQuantity(Long userId, Long bookId, int quantity) {
+        Cart cart = cartFindService.getCart(userId);
+        CartItem cartItem = cart.getCartItems().stream()
+                .filter(ci -> ci.getBook().getId().equals(bookId))
+                .findFirst()
                 .orElseThrow(CartItemNotFoundException::new);
         cartItem.updateQuantity(quantity);
         return CartUpdateResponse.builder()
@@ -83,8 +86,11 @@ public class CartServiceImpl implements CartService {
 
     @Override
     @Transactional
-    public void deleteItem(Long id) {
-        CartItem cartItem = cartItemRepository.findById(id)
+    public void deleteItem(Long userId, Long bookId) {
+        Cart cart = cartFindService.getCart(userId);
+        CartItem cartItem = cart.getCartItems().stream()
+                .filter(ci -> ci.getBook().getId().equals(bookId))
+                .findFirst()
                 .orElseThrow(CartItemNotFoundException::new);
         cartItemRepository.delete(cartItem);
     }

--- a/src/test/java/shop/bookbom/shop/domain/cart/controller/CartControllerTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/cart/controller/CartControllerTest.java
@@ -1,6 +1,8 @@
 package shop.bookbom.shop.domain.cart.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -115,7 +117,8 @@ class CartControllerTest {
     void updateQuantity() throws Exception {
         CartUpdateRequest request = getCartUpdateRequest();
         CartUpdateResponse response = getCartUpdateResponse();
-        when(cartService.updateQuantity(1L, 5)).thenReturn(response);
+        when(resolver.resolveArgument(any(), any(), any(), any())).thenReturn(new UserDto(1L));
+        when(cartService.updateQuantity(anyLong(), anyLong(), anyInt())).thenReturn(response);
         ResultActions perform = mockMvc.perform(put("/shop/carts/items/{id}", 1L)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)));
@@ -132,6 +135,7 @@ class CartControllerTest {
     @DisplayName("장바구니 상품 삭제")
     void deleteItem() throws Exception {
         ResultActions perform = mockMvc.perform(delete("/shop/carts/items/{id}", 1L));
+        when(resolver.resolveArgument(any(), any(), any(), any())).thenReturn(new UserDto(1L));
         perform
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/shop/bookbom/shop/domain/cart/service/CartServiceTest.java
+++ b/src/test/java/shop/bookbom/shop/domain/cart/service/CartServiceTest.java
@@ -126,15 +126,19 @@ class CartServiceTest {
     @DisplayName("장바구니 목록 중 삭제")
     void delete() throws Exception {
         //given
+        Book book = getBook("title1", getPointRate(), getPublisher());
+        ReflectionTestUtils.setField(book, "id", 1L);
         CartItem cartItem = CartItem.builder()
                 .cart(getCart(getMember("test@email.com", getRole(), getRank(getPointRate()))))
-                .book(getBook("title1", getPointRate(), getPublisher()))
+                .book(book)
                 .build();
         ReflectionTestUtils.setField(cartItem, "id", 1L);
-        when(cartItemRepository.findById(1L)).thenReturn(Optional.of(cartItem));
+        Cart cart = getCart(getMember("test@email.com", getRole(), getRank(getPointRate())));
+        cart.addItem(cartItem);
+        when(cartFindService.getCart(any())).thenReturn(cart);
 
         //when
-        cartService.deleteItem(1L);
+        cartService.deleteItem(1L, 1L);
 
         //then
         verify(cartItemRepository).delete(cartItem);
@@ -144,10 +148,11 @@ class CartServiceTest {
     @DisplayName("장바구니 목록 중 삭제 예외")
     void deleteNotExistsCartItem() throws Exception {
         //given
-        when(cartItemRepository.findById(any())).thenReturn(Optional.empty());
+        when(cartFindService.getCart(any())).thenReturn(
+                getCart(getMember("test@email.com", getRole(), getRank(getPointRate()))));
 
         //when & then
-        assertThatThrownBy(() -> cartService.deleteItem(1L))
+        assertThatThrownBy(() -> cartService.deleteItem(1L, 1L))
                 .isInstanceOf(CartItemNotFoundException.class);
     }
 
@@ -156,15 +161,18 @@ class CartServiceTest {
     @DisplayName("장바구니 도서 수량 수정")
     void updateQuantity() throws Exception {
         //given
+        Book book = getBook("title1", getPointRate(), getPublisher());
+        ReflectionTestUtils.setField(book, "id", 1L);
         CartItem cartItem = CartItem.builder()
                 .cart(getCart(getMember("test@email.com", getRole(), getRank(getPointRate()))))
-                .book(getBook("title1", getPointRate(), getPublisher()))
+                .book(book)
                 .build();
         ReflectionTestUtils.setField(cartItem, "id", 1L);
-        when(cartItemRepository.findById(1L)).thenReturn(Optional.of(cartItem));
-
+        Cart cart = getCart(getMember("test@email.com", getRole(), getRank(getPointRate())));
+        cart.addItem(cartItem);
+        when(cartFindService.getCart(any())).thenReturn(cart);
         //when
-        CartUpdateResponse response = cartService.updateQuantity(1L, 20);
+        CartUpdateResponse response = cartService.updateQuantity(1L, 1L, 20);
 
         //then
         assertThat(response.getQuantity()).isEqualTo(20);
@@ -174,15 +182,19 @@ class CartServiceTest {
     @DisplayName("장바구니 도서 수량 수정 예외")
     void updateQuantityException() throws Exception {
         // given
+        Book book = getBook("title1", getPointRate(), getPublisher());
+        ReflectionTestUtils.setField(book, "id", 1L);
         CartItem cartItem = CartItem.builder()
                 .cart(getCart(getMember("test@email.com", getRole(), getRank(getPointRate()))))
-                .book(getBook("title1", getPointRate(), getPublisher()))
+                .book(book)
                 .build();
         ReflectionTestUtils.setField(cartItem, "id", 1L);
-        when(cartItemRepository.findById(1L)).thenReturn(Optional.of(cartItem));
+        Cart cart = getCart(getMember("test@email.com", getRole(), getRank(getPointRate())));
+        cart.addItem(cartItem);
+        when(cartFindService.getCart(any())).thenReturn(cart);
 
         // when & then
-        assertThatThrownBy(() -> cartService.updateQuantity(1L, 0))
+        assertThatThrownBy(() -> cartService.updateQuantity(1L, 1L, 0))
                 .isInstanceOf(CartItemInvalidQuantityException.class);
     }
 


### PR DESCRIPTION
# 설명
- 회원 장바구니 저장에 대한 로직을 수정하였습니다.
 
# 작업내용
- 주문을 하고 난 뒤 장바구니 상품 삭제를 위해 수량 변경과 삭제 로직을 cartItemId를 받는 것이 아닌 bookId를 받는 방식으로 수정하였습니다.
 
